### PR TITLE
fix: improve parallelisation

### DIFF
--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -1,5 +1,5 @@
 import logging
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from flypipe.node_graph import NodeGraph
 from collections import namedtuple
 from abc import ABC, abstractmethod
@@ -72,7 +72,8 @@ class Node(ABC):
 
     def run(self):
         outputs = {}
-        dependency_chain = self.node_graph.get_dependency_chain()
+        dependency_map = self.node_graph.get_dependency_map()
+        result_futures = []
 
         def process_and_cache_node(node_obj, **inputs):
             result = self.process_node(node_obj, **inputs)
@@ -80,16 +81,25 @@ class Node(ABC):
                 outputs[node_obj.__name__] = self.validate_dataframe(
                     node_obj.output_schema, result
                 )
+                for dependency in dependency_map.values():
+                    try:
+                        dependency.remove(node_obj.__name__)
+                    except KeyError:
+                        pass
+                logger.debug(f'Finished processing node {node_obj.__name__}')
             except TypeError as ex:
                 raise TypeError(
-                    f"Validation failure on node {node_name} when checking output schema: \n{str(ex)}"
+                    f"Validation failure on node {node_obj.__name__} when checking output schema: \n{str(ex)}"
                 )
 
-        with ThreadPoolExecutor() as executor:
-            for node_group in dependency_chain:
-                logger.debug(f"Started processing group of nodes {node_group}")
-                result_futures = []
-                for node_name in node_group:
+        def run_valid_nodes():
+            """Run nodes with no yet-to-be run dependencies/inputs"""
+            remaining_nodes = list(dependency_map.keys())
+            for node_name in remaining_nodes:
+                dependencies = dependency_map[node_name]
+                if not dependencies:
+                    logger.debug(f"Started processing node {node_name}")
+
                     node_obj = self.node_graph.get_node(node_name)
                     try:
                         node_inputs = {}
@@ -116,15 +126,21 @@ class Node(ABC):
                         )
 
                     logger.debug(f"Processing node {node_obj.__name__}")
+                    new_task = executor.submit(process_and_cache_node, node_obj, **node_inputs)
+                    # Remove the node from the dependency map so that we don't run it again
+                    dependency_map.pop(node_obj.__name__)
                     result_futures.append(
-                        executor.submit(process_and_cache_node, node_obj, **node_inputs)
+                        new_task
                     )
-                logger.debug("Waiting for group of nodes to finish...")
-                wait(result_futures)
+
+        with ThreadPoolExecutor() as executor:
+            run_valid_nodes()
+            # As each node is completed we check if it's possible to run any new nodes
+            for task in as_completed(result_futures):
                 # This is not actually a no-op- if any exceptions occur during node processing they get re-raised when
                 # calling result()
-                [future.result() for future in result_futures]
-                logger.debug("Finished processing group of nodes")
+                task.result()
+                run_valid_nodes()
         return outputs[self.transformation.__name__]
 
     @classmethod

--- a/flypipe/node_graph.py
+++ b/flypipe/node_graph.py
@@ -29,20 +29,18 @@ class NodeGraph:
     def get_node(self, name):
         return self.graph.nodes[name]['function']
 
-    def get_dependency_chain(self):
-        """
-        Process the graph to get the appropriate order to execute the nodes in.
-        """
-        dependency_chain = []
-        graph = self.graph.copy()
+    def get_dependency_map(self):
+        dependencies = {}
+        for node in self.graph.nodes:
+            dependencies[node] = set()
+        for source, destination in self.graph.edges:
+            dependencies[destination].add(source)
+        return dependencies
+    #
+    # @classmethod
+    # def get_runnable_nodes(cls, execution_graph):
+    #     nodes = [node for node in execution_graph if execution_graph.in_degree(node) == 0]
 
-        while not len(graph) == 0:
-            nodes = [node for node in graph if graph.in_degree(node)==0]
-            dependency_chain.append(nodes)
-            for node in nodes:
-                graph.remove_node(node)
-
-        return dependency_chain
 
     def plot(self):
         plt.title(f'Transformation Graph')

--- a/flypipe/node_graph_test.py
+++ b/flypipe/node_graph_test.py
@@ -2,43 +2,51 @@ from flypipe.node import node
 from flypipe.node_graph import NodeGraph
 
 
-@node()
+@node(type="pandas")
 def a():
     return
 
 
-@node(inputs=[a])
+@node(type="pandas", inputs=[a])
 def b():
     return
 
 
-@node(inputs=[a])
+@node(type="pandas", inputs=[a])
 def c():
     return
 
 
-@node(inputs=[b])
+@node(type="pandas", inputs=[b])
 def d():
     return
 
 
-@node(inputs=[b])
+@node(type="pandas", inputs=[b])
 def e():
     return
 
 
-@node(inputs=[a, c])
+@node(type="pandas", inputs=[a, c])
 def f():
     return
 
 
-@node(inputs=[d, e, f])
+@node(type="pandas", inputs=[d, e, f])
 def g():
     return
 
 
 class TestNodeGraph:
 
-    def test_get_dependency_chain(self):
+    def test_get_dependency_map(self):
         graph = NodeGraph(g)
-        assert graph.get_dependency_chain() == [['a'], ['b', 'c'], ['d', 'e', 'f'], ['g']]
+        assert graph.get_dependency_map() == {
+            "a": set(),
+            "b": {"a"},
+            "c": {"a"},
+            "d": {"b"},
+            "e": {"b"},
+            "f": {"a", "c"},
+            "g": {"d", "e", "f"},
+        }

--- a/flypipe/node_test.py
+++ b/flypipe/node_test.py
@@ -59,8 +59,8 @@ class TestNode:
             pd.DataFrame(
                 {
                     "name": ["Albert", "Bob", "Chris", "Chris"],
-                    "fruit": ["banana", "apple", "strawberry", "apple"],
                     "age": [30, 25, 28, 28],
+                    "fruit": ["banana", "apple", "strawberry", "apple"],
                 }
             ),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ build-backend = "setuptools.build_meta"
 # This line makes setuptools choose the package version dynamically via setuptools_scm
 [tool.setuptools_scm]
 write_to = "version.py"
+
+[tool.pytest.ini_options]
+log_cli = 1


### PR DESCRIPTION
Prior functionality was:
- Iterate through the graph and identify all nodes with no dependencies. Extract these as the first nodes to run and remove them from the graph.
- Repeat

I've improved this to run per node rather than once each wave of nodes has been computed.