### PR TITLE
fix: remove second upload of wheel which is causing an error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,11 +55,6 @@ jobs:
           flit publish
         env:
           FLIT_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Upload wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: flypipe-${{ env.VERSION_NUMBER }}-py3-none-any.whl
-          path: ./dist/flypipe-${{ env.VERSION_NUMBER }}-py3-none-any.whl
 
   build-docs:
     needs: deploy-pypi


### PR DESCRIPTION
Action https://github.com/actions/upload-artifact errors out in v4 if you attempt to upload an artifact with the same name multiple times. We're doing precisely that at the moment because both predeploy and deploy-pypi are running that action. I don't see any difference between building the wheel before or after deployment to pypi so am pretty sure we should be good just to remove the latter upload. 