### PR TITLE
[152] upgrade actions/upload-pages-artifact from version v1 to v3 and…

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Sphinx Documentation
         run: sh docs/build_docs.sh
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/build
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Pipeline deploy-> step build-docs is failling

`Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/`

GitActions Failed link: https://github.com/flypipe/flypipe/actions/runs/13134752867/job/36647943285

This is caused because `actions/upload-pages-artifact@v1` is still using `actions/upload-artifact@v3` that is deprecated, found [here](https://github.com/actions/upload-pages-artifact/blob/84bb4cd4b733d5c320c9c9cfbc354937524f4d64/action.yml#L72). Version v3 is using the  `actions/upload-artifact@v4`, see [here](https://github.com/actions/upload-pages-artifact/blob/56afc609e74202658d3ffba0e8f6dda462b719fa/action.yml#L77)

Already upgraded `actions/deploy-pages@v1` to `actions/deploy-pages@v4` for the same reason