### PR TITLE
148 add support to pysparksqlconnectdataframedataframe

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install backend requirements
       shell: bash
       run: |

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -13,6 +13,7 @@ runs:
     - name: Install backend requirements
       shell: bash
       run: |
+        python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m pip install -r ./local/requirements.txt
     - name: Setup Node

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -43,7 +43,7 @@ jobs:
           # Check installation
           pandoc -v
       - name: Build Sphinx Documentation
-        run: sh docs/build_docs.sh
+        run: make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -30,6 +30,11 @@ jobs:
           fetch-depth: 0
       - name: Setup dependencies
         uses: ./.github/actions/setup-dependencies
+      - name: Setup docker compose
+        run: |
+          curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Run formatter on backend (black)
         run: make black-check
       - name: Run formatter on frontend (prettier)

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -28,13 +28,13 @@ jobs:
         with:
           # Fetch all tags/branches to run diff-cover properly
           fetch-depth: 0
-      - name: Setup dependencies
-        uses: ./.github/actions/setup-dependencies
       - name: Setup docker compose
         run: |
           curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
           chmod +x /usr/local/bin/docker-compose
           docker-compose version
+      - name: Setup dependencies
+        uses: ./.github/actions/setup-dependencies
       - name: Run formatter on backend (black)
         run: make black-check
       - name: Run formatter on frontend (prettier)

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -38,5 +38,7 @@ jobs:
           yarn prettier-check
       - name: Run linter (ruff)
         run: make lint
-      - name: Run unit tests
-        run: make coverage
+      - name: Run unit tests using Spark Session
+        run: make coverage USE_SPARK_CONNECT=0
+      - name: Run unit tests using Spark Connect Session
+        run: make coverage USE_SPARK_CONNECT=1

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     # The type of runner that the job will run on
-    runs-on: debian-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: debian-latest
     timeout-minutes: 30
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,12 @@ min_coverage=85
 min_branch_coverage=95
 USE_SPARK_CONNECT=0
 
-up:
-	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml up --build
+build-image:
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml build
+.PHONY: build-image
+
+up: build-image
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml up
 .PHONY: up
 
 down:
@@ -33,7 +37,6 @@ lint:
 .PHONY: lint
 
 coverage:
-	#docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --remove-orphans --entrypoint "" flypipe-jupyter sh -c "pytest --rootdir flypipe -n $(PYTEST_THREADS) -k '_test.py' --ignore-glob '*_spark_connect_test.py' --cov=flypipe --no-cov-on-fail --cov-fail-under=$(min_coverage) flypipe"
 	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --remove-orphans --entrypoint "" flypipe-jupyter sh -c "export USE_SPARK_CONNECT=$(USE_SPARK_CONNECT) && pytest --rootdir flypipe -n $(PYTEST_THREADS) -k '_test.py' --cov=flypipe --no-cov-on-fail --cov-fail-under=$(min_coverage) flypipe"
 .PHONY: coverage
 
@@ -46,14 +49,17 @@ branch-coverage:
 	diff-cover coverage.xml --fail-under=$(min_branch_coverage)
 .PHONY: branch-coverage
 
-jupyter-bash:
-	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml build
+jupyter-bash: build-image
 	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" -it flypipe-jupyter bash
 .PHONY: jupyter-bash
 
 docs:
-	sh ./docs/build_docs_dev.sh
+	sh docs/build_docs.sh
 .PHONY: docs
+
+docs-dev: build-image
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --remove-orphans --entrypoint "" flypipe-jupyter sh -c "sh ./docs/build_docs_dev.sh"
+.PHONY: docs-dev
 
 build:
 	flit build --format wheel

--- a/Makefile
+++ b/Makefile
@@ -4,39 +4,41 @@ LOCAL_DIR=./local
 PYTEST_THREADS ?=$(shell echo $$((`getconf _NPROCESSORS_ONLN` / 3)))
 min_coverage=85
 min_branch_coverage=95
+USE_SPARK_CONNECT=0
 
 up:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml up --build
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml up --build
 .PHONY: up
 
 down:
 	rm -r $(LOCAL_DIR)/data || true
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml down -v --rmi all
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml down -v --rmi all
 .PHONY: down
 
 ping:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter ./wait-for-it.sh -h flypipe-mariadb -p 3306
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter ./wait-for-it.sh -h flypipe-hive-metastore -p 9083
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter ./wait-for-it.sh -h flypipe-mariadb -p 3306
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter ./wait-for-it.sh -h flypipe-hive-metastore -p 9083
 .PHONY: ping
 
 black:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "black flypipe"
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "black flypipe"
 .PHONY: black
 
 black-check:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "black flypipe --check"
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "black flypipe --check"
 .PHONY: black-check
 
 lint:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "python -m ruff check flypipe"
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "python -m ruff check flypipe"
 .PHONY: lint
 
 coverage:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "pytest -n $(PYTEST_THREADS) -k '_test.py' --cov=flypipe --no-cov-on-fail --cov-fail-under=$(min_coverage) flypipe"
+	#docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --remove-orphans --entrypoint "" flypipe-jupyter sh -c "pytest --rootdir flypipe -n $(PYTEST_THREADS) -k '_test.py' --ignore-glob '*_spark_connect_test.py' --cov=flypipe --no-cov-on-fail --cov-fail-under=$(min_coverage) flypipe"
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --remove-orphans --entrypoint "" flypipe-jupyter sh -c "export USE_SPARK_CONNECT=$(USE_SPARK_CONNECT) && pytest --rootdir flypipe -n $(PYTEST_THREADS) -k '_test.py' --cov=flypipe --no-cov-on-fail --cov-fail-under=$(min_coverage) flypipe"
 .PHONY: coverage
 
 test:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --rm --entrypoint "" flypipe-jupyter sh -c "pytest -n $(PYTEST_THREADS) -k '_test.py' -vv $(f)"
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --remove-orphans --entrypoint "" flypipe-jupyter sh -c "export USE_SPARK_CONNECT=$(USE_SPARK_CONNECT) && pytest -n $(PYTEST_THREADS) -k '_test.py' -vv $(f) --rootdir flypipe"
 .PHONY: test
 
 branch-coverage:
@@ -45,8 +47,8 @@ branch-coverage:
 .PHONY: branch-coverage
 
 jupyter-bash:
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml build
-	docker compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" -it flypipe-jupyter bash
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml build
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" -it flypipe-jupyter bash
 .PHONY: jupyter-bash
 
 docs:
@@ -56,3 +58,8 @@ docs:
 build:
 	flit build --format wheel
 .PHONY: build
+
+spark-bash:
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml build
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" -it spark-master bash
+.PHONY: spark-bash

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ down:
 .PHONY: down
 
 ping:
-	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter ./wait-for-it.sh -h flypipe-mariadb -p 3306
-	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter ./wait-for-it.sh -h flypipe-hive-metastore -p 9083
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter sh -c "chmod +x ./wait-for-it.sh && ./wait-for-it.sh -h flypipe-mariadb -p 3306"
+	docker-compose -f $(LOCAL_DIR)/docker-compose.yaml run --entrypoint "" flypipe-jupyter sh -c "chmod +x ./wait-for-it.sh && ./wait-for-it.sh -h flypipe-hive-metastore -p 9083"
 .PHONY: ping
 
 black:

--- a/docs/source/contribute/contribute.md
+++ b/docs/source/contribute/contribute.md
@@ -33,7 +33,8 @@ Access JupyterLab http://127.0.0.1:8888/lab
 
 Runs unit tests and coverage
 
-`make coverage`
+`make coverage USE_SPARK_CONNECT=0` runs test coverage using spark session
+`make coverage USE_SPARK_CONNECT=1` runs test coverage using spark connect session
 
 **black**
 

--- a/docs/source/contribute/contribute.md
+++ b/docs/source/contribute/contribute.md
@@ -15,9 +15,9 @@ Access JupyterLab http://127.0.0.1:8888/lab
 
 `make down`
 
-### Rebuilding documents
+### Rebuilding documents (Locally)
 
-`make docs`
+`make docs-dev`
 
 ### Other useful commands
 

--- a/docs/source/notebooks/tutorial/unittests.ipynb
+++ b/docs/source/notebooks/tutorial/unittests.ipynb
@@ -36,8 +36,8 @@
     "@pytest.fixture(scope=\"function\")\n",
     "def spark():\n",
     "    # If running local, please set up your Spark environment\n",
-    "    from flypipe.tests.spark import spark\n",
-    "\n",
+    "    from flypipe.tests.spark import build_spark\n",
+    "    spark = build_spark()\n",
     "    # create a temporary view\n",
     "    (\n",
     "        spark.createDataFrame(\n",
@@ -250,7 +250,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1m======================================= test session starts ========================================\u001b[0m\n",
+      "\u001B[1m======================================= test session starts ========================================\u001B[0m\n",
       "platform linux -- Python 3.9.17, pytest-7.1.3, pluggy-1.2.0\n",
       "rootdir: /notebooks/docs/tutorial\n",
       "plugins: anyio-3.7.0, mock-3.9.0, xdist-3.3.1\n",
@@ -270,15 +270,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[32m.\u001b[0m\u001b[33m                                                 [100%]\u001b[0m\n",
+      "\u001B[32m.\u001B[0m\u001B[32m.\u001B[0m\u001B[32m.\u001B[0m\u001B[32m.\u001B[0m\u001B[32m.\u001B[0m\u001B[32m.\u001B[0m\u001B[33m                                                 [100%]\u001B[0m\n",
       "\n",
-      "\u001b[33m========================================= warnings summary =========================================\u001b[0m\n",
+      "\u001B[33m========================================= warnings summary =========================================\u001B[0m\n",
       "t_61fe84b0633f469880cbe1488792adea.py: 14 warnings\n",
       "  /usr/local/lib/python3.9/site-packages/pyspark/pandas/typedef/typehints.py:181: DeprecationWarning: Converting `np.character` to a dtype is deprecated. The current result is `np.dtype(np.str_)` which is not strictly correct. Note that `np.character` is generally deprecated and 'S1' should be used.\n",
       "    elif tpe in (bytes, np.character, np.bytes_, np.string_):\n",
       "\n",
       "-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n",
-      "\u001b[33m================================== \u001b[32m6 passed\u001b[0m, \u001b[33m\u001b[1m14 warnings\u001b[0m\u001b[33m in 6.14s\u001b[0m\u001b[33m ==================================\u001b[0m\n"
+      "\u001B[33m================================== \u001B[32m6 passed\u001B[0m, \u001B[33m\u001B[1m14 warnings\u001B[0m\u001B[33m in 6.14s\u001B[0m\u001B[33m ==================================\u001B[0m\n"
      ]
     },
     {

--- a/flypipe/cache/cache_context_test.py
+++ b/flypipe/cache/cache_context_test.py
@@ -10,7 +10,6 @@ from flypipe.cache.cache_context import CacheContext
 from flypipe.node import node
 
 
-
 class GenericCache(Cache):
     def __init__(self):
         self.cache_csv = f"{str(uuid4())}.csv"

--- a/flypipe/cache/cache_context_test.py
+++ b/flypipe/cache/cache_context_test.py
@@ -9,8 +9,6 @@ from flypipe.cache.cache import Cache
 from flypipe.cache.cache_context import CacheContext
 from flypipe.node import node
 
-# noinspection PyUnresolvedReferences
-from flypipe.tests.conftest import spark
 
 
 class GenericCache(Cache):
@@ -75,13 +73,13 @@ class TestCacheContext:
         cache_context.read()
         cache_context.exists()
 
-    def test_write_read_spark(self):
+    def test_write_read_spark(self, spark):
         cache_context = CacheContext(spark=spark, cache=GenericCacheSpark())
         cache_context.write(pd.DataFrame(data={"col1": [1]}))
         cache_context.read()
         cache_context.exists()
 
-    def test_write_non_spark(self):
+    def test_write_non_spark(self, spark):
         cache_context = CacheContext(spark=spark, cache=GenericCache())
 
         with pytest.raises(TypeError):
@@ -91,7 +89,7 @@ class TestCacheContext:
         cache_context = CacheContext(cache=GenericCache())
         cache_context.exists()
 
-    def test_exists_spark(self):
+    def test_exists_spark(self, spark):
         cache_context = CacheContext(spark=spark, cache=GenericCacheSpark())
         cache_context.exists()
 
@@ -100,7 +98,7 @@ class TestCacheContext:
         with pytest.raises(RuntimeError):
             cache_context.exists()
 
-    def test_exists_no_spark_cache(self):
+    def test_exists_no_spark_cache(self, spark):
         cache_context = CacheContext(spark=spark, cache=GenericCache())
         with pytest.raises(TypeError):
             cache_context.exists()

--- a/flypipe/cache/cache_test.py
+++ b/flypipe/cache/cache_test.py
@@ -15,7 +15,6 @@ from flypipe.schema import Schema, Column
 from flypipe.schema.types import Integer
 
 
-
 class GenericCache(Cache):
     def __init__(self):
         self.cache_name = str(uuid4()).replace("-", "_")
@@ -114,9 +113,8 @@ class TestCache:
                 try:
                     spark.read.table(self.cache_name)
                     return spark.table(self.cache_name).count() > 0
-                except:
+                except Exception:
                     return False
-
 
         cache = GenericCache2()
 

--- a/flypipe/conftest.py
+++ b/flypipe/conftest.py
@@ -1,13 +1,12 @@
 import sys
-
 import pytest
 
-from flypipe.tests.spark import spark as spark_session
+pytest.register_assert_rewrite("src.assert_pyspark_df_equal")
 
 # Skip writing pyc files on a readonly filesystem.
 sys.dont_write_bytecode = True
 
-
-@pytest.fixture(scope="class", autouse=False)
-def spark():
-    return spark_session
+@pytest.fixture(scope="function", autouse=False)
+def spark(request):
+    from flypipe.tests.spark import build_spark
+    return build_spark()

--- a/flypipe/conftest.py
+++ b/flypipe/conftest.py
@@ -6,7 +6,9 @@ pytest.register_assert_rewrite("src.assert_pyspark_df_equal")
 # Skip writing pyc files on a readonly filesystem.
 sys.dont_write_bytecode = True
 
+
 @pytest.fixture(scope="function", autouse=False)
 def spark(request):
     from flypipe.tests.spark import build_spark
+
     return build_spark()

--- a/flypipe/converter/dataframe_test.py
+++ b/flypipe/converter/dataframe_test.py
@@ -30,14 +30,13 @@ class TestDataFrameConverter:
         df = DataFrameConverter().convert(pandas_df, DataFrameType.PANDAS)
         assert_dataframes_equals(df, pandas_df)
 
-    @pytest.mark.skip("Test succeeds locally but fails on GitHub")
+
     def test_convert_pandas_to_pandas_on_spark(
         self, spark, pandas_df, pandas_on_spark_df
     ):
         df = DataFrameConverter(spark).convert(pandas_df, DataFrameType.PANDAS_ON_SPARK)
         assert_dataframes_equals(df, pandas_on_spark_df)
 
-    @pytest.mark.skip("Test succeeds locally but fails on GitHub")
     def test_convert_pandas_to_pyspark(self, spark, pandas_df, pyspark_df):
         df = DataFrameConverter(spark).convert(pandas_df, DataFrameType.PYSPARK)
         assert_dataframes_equals(df, pyspark_df)
@@ -48,8 +47,7 @@ class TestDataFrameConverter:
         df = DataFrameConverter(spark).convert(pandas_on_spark_df, DataFrameType.PANDAS)
         assert_dataframes_equals(df, pandas_df)
 
-    @pytest.mark.skip("Test succeeds locally but fails on GitHub")
-    def test_convert_pandas_on_spark_to_pyspark(self, pandas_on_spark_df, pyspark_df):
+    def test_convert_pandas_on_spark_to_pyspark(self, spark, pandas_on_spark_df, pyspark_df):
         df = DataFrameConverter(spark).convert(
             pandas_on_spark_df, DataFrameType.PYSPARK
         )
@@ -59,8 +57,7 @@ class TestDataFrameConverter:
         df = DataFrameConverter(spark).convert(pyspark_df, DataFrameType.PANDAS)
         assert_dataframes_equals(df, pandas_df)
 
-    @pytest.mark.skip("Test succeeds locally but fails on GitHub")
-    def test_convert_pyspark_to_pandas_on_spark(self, pyspark_df, pandas_on_spark_df):
+    def test_convert_pyspark_to_pandas_on_spark(self, spark, pyspark_df, pandas_on_spark_df):
         df = DataFrameConverter(spark).convert(
             pyspark_df, DataFrameType.PANDAS_ON_SPARK
         )

--- a/flypipe/converter/dataframe_test.py
+++ b/flypipe/converter/dataframe_test.py
@@ -9,13 +9,6 @@ from flypipe.utils import assert_dataframes_equals, DataFrameType
 
 
 @pytest.fixture(scope="function")
-def spark():
-    from flypipe.tests.spark import spark
-
-    return spark
-
-
-@pytest.fixture(scope="function")
 def pandas_df():
     return pd.DataFrame(data={"col1": [1, 2, 3], "col2": ["1a", "2a", "3a"]})
 

--- a/flypipe/converter/dataframe_test.py
+++ b/flypipe/converter/dataframe_test.py
@@ -30,7 +30,6 @@ class TestDataFrameConverter:
         df = DataFrameConverter().convert(pandas_df, DataFrameType.PANDAS)
         assert_dataframes_equals(df, pandas_df)
 
-
     def test_convert_pandas_to_pandas_on_spark(
         self, spark, pandas_df, pandas_on_spark_df
     ):
@@ -47,7 +46,9 @@ class TestDataFrameConverter:
         df = DataFrameConverter(spark).convert(pandas_on_spark_df, DataFrameType.PANDAS)
         assert_dataframes_equals(df, pandas_df)
 
-    def test_convert_pandas_on_spark_to_pyspark(self, spark, pandas_on_spark_df, pyspark_df):
+    def test_convert_pandas_on_spark_to_pyspark(
+        self, spark, pandas_on_spark_df, pyspark_df
+    ):
         df = DataFrameConverter(spark).convert(
             pandas_on_spark_df, DataFrameType.PYSPARK
         )
@@ -57,7 +58,9 @@ class TestDataFrameConverter:
         df = DataFrameConverter(spark).convert(pyspark_df, DataFrameType.PANDAS)
         assert_dataframes_equals(df, pandas_df)
 
-    def test_convert_pyspark_to_pandas_on_spark(self, spark, pyspark_df, pandas_on_spark_df):
+    def test_convert_pyspark_to_pandas_on_spark(
+        self, spark, pyspark_df, pandas_on_spark_df
+    ):
         df = DataFrameConverter(spark).convert(
             pyspark_df, DataFrameType.PANDAS_ON_SPARK
         )

--- a/flypipe/dataframe/dataframe_wrapper_test.py
+++ b/flypipe/dataframe/dataframe_wrapper_test.py
@@ -10,6 +10,7 @@ from flypipe.dataframe.pandas_on_spark_dataframe_wrapper import (
 from flypipe.dataframe.spark_dataframe_wrapper import SparkDataFrameWrapper
 from flypipe.schema.types import Boolean, Decimal, String, Unknown
 
+
 class DummyDataFrameWrapper(DataFrameWrapper):
     """Dummy subclass of abstract class DataFrameWrapper so we can use it in tests"""
 
@@ -116,4 +117,3 @@ class TestDataFrameWrapper:
             str(ex.value)
             == "Unable to cast to flypipe type String- no dataframe type registered"
         )
-

--- a/flypipe/dataframe/dataframe_wrapper_test.py
+++ b/flypipe/dataframe/dataframe_wrapper_test.py
@@ -9,8 +9,6 @@ from flypipe.dataframe.pandas_on_spark_dataframe_wrapper import (
 )
 from flypipe.dataframe.spark_dataframe_wrapper import SparkDataFrameWrapper
 from flypipe.schema.types import Boolean, Decimal, String, Unknown
-from flypipe.tests.spark import spark
-
 
 class DummyDataFrameWrapper(DataFrameWrapper):
     """Dummy subclass of abstract class DataFrameWrapper so we can use it in tests"""
@@ -37,36 +35,50 @@ class TestDataFrameWrapper:
     """Tests for DataFrameWrapper"""
 
     @pytest.mark.parametrize(
-        "df,expected_class",
+        "data,type,expected_class",
         [
-            (pd.DataFrame({"column": [1]}), PandasDataFrameWrapper),
+            (pd.DataFrame({"column": [1]}), "pandas", PandasDataFrameWrapper),
             (
-                spark.createDataFrame(schema=["column"], data=[[1]]),
+                {"schema": ["column"], "data": [[1]]},
+                "spark",
                 SparkDataFrameWrapper,
             ),
             (
-                spark.createDataFrame(schema=["column"], data=[[1]]).pandas_api(),
+                {"schema": ["column"], "data": [[1]]},
+                "pandas_api",
                 PandasOnSparkDataFrameWrapper,
             ),
         ],
     )
-    def test_get_instance(self, df, expected_class):
+    def test_get_instance(self, data, type, expected_class, spark):
+        if type == "pandas":
+            df = data
+        else:
+            df = spark.createDataFrame(**data)
+            if type == "pandas_api":
+                df = df.pandas_api()
         assert isinstance(DataFrameWrapper.get_instance(spark, df), expected_class)
 
     @pytest.mark.parametrize(
-        "df",
+        "data,type",
         [
-            pd.DataFrame({"col1": [1], "col2": [2]}),
-            spark.createDataFrame(schema=("col1", "col2"), data=[[1, 2]]),
-            spark.createDataFrame(schema=("col1", "col2"), data=[[1, 2]]).pandas_api(),
+            (pd.DataFrame({"col1": [1], "col2": [2]}), "pandas"),
+            ({"schema": ["col1", "col2"], "data": [[1, 2]]}, "spark"),
+            ({"schema": ["col1", "col2"], "data": [[1, 2]]}, "pandas_api"),
         ],
     )
-    def test_select_columns_out_of_place(self, df):
+    def test_select_columns_out_of_place(self, spark, data, type):
         """
         Ensure that DataFrameWrapper.select_columns does the selection operation out-of-place and returns a new
         dataframe wrapper, therefore the original dataframe wrapper should be untouched.
         """
         # TODO- doesn't look like we're testing anything here?
+        if type == "pandas":
+            df = data
+        else:
+            df = spark.createDataFrame(**data)
+            if type == "pandas_api":
+                df = df.pandas_api()
         df_wrapper = DataFrameWrapper.get_instance(spark, df)
         df_wrapper2 = df_wrapper.select_columns("col1")  # noqa: F841
 
@@ -104,3 +116,4 @@ class TestDataFrameWrapper:
             str(ex.value)
             == "Unable to cast to flypipe type String- no dataframe type registered"
         )
+

--- a/flypipe/dataframe/pandas_dataframe_wrapper_test.py
+++ b/flypipe/dataframe/pandas_dataframe_wrapper_test.py
@@ -19,9 +19,6 @@ from flypipe.schema.types import (
     String,
 )
 
-# noinspection PyUnresolvedReferences
-from flypipe.tests.conftest import spark
-
 
 class TestPandasDataFrameWrapper:
     """Tests for Pandas Data Frame"""
@@ -73,7 +70,7 @@ class TestPandasDataFrameWrapper:
         with pytest.raises(DataFrameMissingColumns):
             df_wrapper.select_columns(["col1", "col4"])
 
-    def test_get_column_flypipe_type(self):
+    def test_get_column_flypipe_type(self, spark):
         df = pd.DataFrame(
             {
                 "c1": [True],

--- a/flypipe/dataframe/pandas_on_spark_dataframe_wrapper_test.py
+++ b/flypipe/dataframe/pandas_on_spark_dataframe_wrapper_test.py
@@ -18,14 +18,15 @@ from flypipe.schema.types import (
 class TestPandasOnSparkDataFrameWrapper:
     """Tests for PandasOnSpark"""
 
-    def test_select_column_1(self):
-        df = ps.DataFrame(
+    def test_select_column_1(self, spark):
+        df = spark.createDataFrame(pd.DataFrame(
             {
                 "col1": [True, False],
                 "col2": ["Hello", "World"],
                 "col3": ["Banana", "Apple"],
             }
-        )
+        )).pandas_api()
+
         expected_df = pd.DataFrame(
             {
                 "col1": [True, False],
@@ -37,14 +38,15 @@ class TestPandasOnSparkDataFrameWrapper:
             df_wrapper.select_columns("col1", "col2").df.to_pandas(), expected_df
         )
 
-    def test_select_column_2(self):
-        df = ps.DataFrame(
+    def test_select_column_2(self, spark):
+        df = spark.createDataFrame(pd.DataFrame(
             {
                 "col1": [True, False],
                 "col2": ["Hello", "World"],
                 "col3": ["Banana", "Apple"],
             }
-        )
+        )).pandas_api()
+
         expected_df = pd.DataFrame(
             {
                 "col1": [True, False],
@@ -56,14 +58,15 @@ class TestPandasOnSparkDataFrameWrapper:
             df_wrapper.select_columns(["col1", "col2"]).df.to_pandas(), expected_df
         )
 
-    def test_select_column_missing_column(self):
-        df = ps.DataFrame(
+    def test_select_column_missing_column(self, spark):
+        df = spark.createDataFrame(pd.DataFrame(
             {
                 "col1": [True, False],
                 "col2": ["Hello", "World"],
                 "col3": ["Banana", "Apple"],
             }
-        )
+        )).pandas_api()
+
         df_wrapper = DataFrameWrapper.get_instance(None, df)
 
         with pytest.raises(DataFrameMissingColumns):

--- a/flypipe/dataframe/pandas_on_spark_dataframe_wrapper_test.py
+++ b/flypipe/dataframe/pandas_on_spark_dataframe_wrapper_test.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pyspark.pandas as ps
 import pytest
 from pandas.testing import assert_frame_equal
 from pyspark.sql.types import (
@@ -19,13 +18,15 @@ class TestPandasOnSparkDataFrameWrapper:
     """Tests for PandasOnSpark"""
 
     def test_select_column_1(self, spark):
-        df = spark.createDataFrame(pd.DataFrame(
-            {
-                "col1": [True, False],
-                "col2": ["Hello", "World"],
-                "col3": ["Banana", "Apple"],
-            }
-        )).pandas_api()
+        df = spark.createDataFrame(
+            pd.DataFrame(
+                {
+                    "col1": [True, False],
+                    "col2": ["Hello", "World"],
+                    "col3": ["Banana", "Apple"],
+                }
+            )
+        ).pandas_api()
 
         expected_df = pd.DataFrame(
             {
@@ -39,13 +40,15 @@ class TestPandasOnSparkDataFrameWrapper:
         )
 
     def test_select_column_2(self, spark):
-        df = spark.createDataFrame(pd.DataFrame(
-            {
-                "col1": [True, False],
-                "col2": ["Hello", "World"],
-                "col3": ["Banana", "Apple"],
-            }
-        )).pandas_api()
+        df = spark.createDataFrame(
+            pd.DataFrame(
+                {
+                    "col1": [True, False],
+                    "col2": ["Hello", "World"],
+                    "col3": ["Banana", "Apple"],
+                }
+            )
+        ).pandas_api()
 
         expected_df = pd.DataFrame(
             {
@@ -59,13 +62,15 @@ class TestPandasOnSparkDataFrameWrapper:
         )
 
     def test_select_column_missing_column(self, spark):
-        df = spark.createDataFrame(pd.DataFrame(
-            {
-                "col1": [True, False],
-                "col2": ["Hello", "World"],
-                "col3": ["Banana", "Apple"],
-            }
-        )).pandas_api()
+        df = spark.createDataFrame(
+            pd.DataFrame(
+                {
+                    "col1": [True, False],
+                    "col2": ["Hello", "World"],
+                    "col3": ["Banana", "Apple"],
+                }
+            )
+        ).pandas_api()
 
         df_wrapper = DataFrameWrapper.get_instance(None, df)
 

--- a/flypipe/dataframe/spark_dataframe_wrapper_test.py
+++ b/flypipe/dataframe/spark_dataframe_wrapper_test.py
@@ -15,7 +15,7 @@ from pyspark.sql.types import (
     TimestampType,
     DateType,
 )
-from pyspark_test import assert_pyspark_df_equal
+from flypipe.tests.pyspark_test import assert_pyspark_df_equal
 
 from flypipe.dataframe.dataframe_wrapper import DataFrameWrapper
 from flypipe.exceptions import DataFrameMissingColumns
@@ -33,13 +33,6 @@ from flypipe.schema.types import (
     DateTime,
     Date,
 )
-
-
-@pytest.fixture
-def spark():
-    from flypipe.tests.spark import spark
-
-    return spark
 
 
 class TestSparkDataFrameWrapper:
@@ -61,7 +54,6 @@ class TestSparkDataFrameWrapper:
             ],
         )
         df_wrapper = DataFrameWrapper.get_instance(None, df)
-
         assert_pyspark_df_equal(
             df_wrapper.select_columns("col1", "col2").df, expected_df
         )

--- a/flypipe/datasource/spark_test.py
+++ b/flypipe/datasource/spark_test.py
@@ -2,7 +2,7 @@ from decimal import Decimal as PythonDecimal
 
 import pytest
 from pyspark.sql.types import StructType, StructField, DecimalType
-from pyspark_test import assert_pyspark_df_equal
+from flypipe.tests.pyspark_test import assert_pyspark_df_equal
 
 from flypipe import node
 from flypipe.datasource.spark import Spark
@@ -11,8 +11,7 @@ from flypipe.schema.types import Decimal
 
 
 @pytest.fixture(scope="function")
-def spark():
-    from flypipe.tests.spark import spark
+def spark_view(spark):
 
     (
         spark.createDataFrame(
@@ -43,10 +42,10 @@ def spark():
 class TestSparkDataSource:
     """Tests for SparkDataSource"""
 
-    def test_load(self, spark):
+    def test_load(self, spark_view):
         """
         Test basic functionality of the datasource i.e from Spark('dummy_table1').select('c1') we a) pick up the
-        contents of dummy_table1 which we earlier prepared in the spark fixture and b) limit the contents to the
+        contents of dummy_table1 which we earlier prepared in the spark_view fixture and b) limit the contents to the
         selected c1 column.
         """
         schema = Schema([Column("c1", Decimal(16, 2), "dummy")])
@@ -59,13 +58,13 @@ class TestSparkDataSource:
         def t1(dummy_table1):
             return dummy_table1
 
-        df_expected = spark.createDataFrame(
+        df_expected = spark_view.createDataFrame(
             schema=StructType([StructField("c1", DecimalType(16, 2))]),
             data=[(PythonDecimal(1),)],
         )
-        assert_pyspark_df_equal(df_expected, t1.run(spark, parallel=False))
+        assert_pyspark_df_equal(df_expected, t1.run(spark_view, parallel=False))
 
-    def test_multiple_sources(self, spark):
+    def test_multiple_sources(self, spark_view):
         """
         Verify that everything works ok with multiple datasources.
         """
@@ -122,7 +121,7 @@ class TestSparkDataSource:
         def t4(t0, t1, t2, t3):
             return t0.join(t1).join(t2).join(t3)
 
-        df_expected = spark.createDataFrame(
+        df_expected = spark_view.createDataFrame(
             schema=StructType(
                 [
                     StructField("c0", DecimalType(16, 2)),
@@ -135,9 +134,9 @@ class TestSparkDataSource:
                 (PythonDecimal(0), PythonDecimal(1), PythonDecimal(2), PythonDecimal(3))
             ],
         )
-        assert_pyspark_df_equal(df_expected, t4.run(spark, parallel=False))
+        assert_pyspark_df_equal(df_expected, t4.run(spark_view, parallel=False))
 
-    def test_datasource_consolidate_columns(self, spark, mocker):
+    def test_datasource_consolidate_columns(self, spark_view, mocker):
         """
         When multiple nodes use a single table in a datasource then we expect that:
         a) the requested columns consolidate into a single query (i.e one query for col1 and col2 and not a query for
@@ -185,12 +184,12 @@ class TestSparkDataSource:
         # Filthy hack to stop the spy removing the __name__ attribute from the function
         spark_dummy_table_2.function.__name__ = func_name2
 
-        t3.run(spark, parallel=False)
+        t3.run(spark_view, parallel=False)
         spy.assert_not_called()
         spy2.assert_called_once()
 
         assert_pyspark_df_equal(
             spy2.spy_return,
-            spark.createDataFrame(schema=("c0", "c1"), data=[(0, 1)]),
+            spark_view.createDataFrame(schema=("c0", "c1"), data=[(0, 1)]),
             check_dtype=False,
         )

--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -406,7 +406,7 @@ class Node:
     def html(
         self,
         spark=None,
-        height=1000,
+        height=800,
         inputs=None,
         pandas_on_spark_use_pandas=False,
         parameters=None,

--- a/flypipe/node_test.py
+++ b/flypipe/node_test.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pandas as pd
@@ -7,7 +8,8 @@ import pyspark.sql.functions as F
 import pytest
 from pandas.testing import assert_frame_equal
 from pyspark.sql import DataFrame
-from pyspark_test import assert_pyspark_df_equal
+from pyspark.sql.connect.dataframe import DataFrame as SqlConnectDataFrame
+from flypipe.tests.pyspark_test import assert_pyspark_df_equal
 
 from flypipe.cache.cache import Cache
 from flypipe.config import config_context
@@ -23,8 +25,7 @@ from flypipe.utils import DataFrameType, dataframe_type
 
 
 @pytest.fixture(scope="function")
-def spark():
-    from flypipe.tests.spark import spark
+def spark_view(spark):
 
     spark.createDataFrame(
         schema=("c0", "c1"),
@@ -113,7 +114,7 @@ class TestNode:
         assert_frame_equal(t5.run(parallel=False), df[["color", "fruit"]])
         assert_frame_equal(t6.run(parallel=False), df[["color", "fruit"]])
 
-    def test_conversion_after_output_column_filter(self, spark, mocker):
+    def test_conversion_after_output_column_filter(self, spark_view, mocker):
         """
         a) When processing the output of a node we only select columns which are requested by child nodes.
         b) When processing a child node we convert all incoming input dataframes from parent nodes to the same type as
@@ -129,7 +130,7 @@ class TestNode:
             return dummy_table1
 
         spy = mocker.spy(DataFrameConverter, "convert")
-        t1.run(spark, parallel=False)
+        t1.run(spark_view, parallel=False)
         assert spy.call_args.args[1].columns == ["c1"]
 
     def test_alias_run(self):
@@ -160,7 +161,7 @@ class TestNode:
         ],
     )
     def test_input_dataframes_type(
-        self, spark, mocker, extra_run_config, expected_df_type
+        self, spark_view, mocker, extra_run_config, expected_df_type
     ):
         stub = mocker.stub()
 
@@ -172,7 +173,7 @@ class TestNode:
 
         @node(type="pyspark")
         def t2():
-            return spark.createDataFrame(
+            return spark_view.createDataFrame(
                 schema=("name", "fruit"), data=[("Chris", "Banana")]
             )
 
@@ -187,7 +188,7 @@ class TestNode:
             stub(t1, t2)
             return t1.merge(t2)
 
-        t3.run(spark, parallel=False, **extra_run_config)
+        t3.run(spark_view, parallel=False, **extra_run_config)
         assert dataframe_type(stub.call_args[0][0]) == expected_df_type
         assert dataframe_type(stub.call_args[0][1]) == expected_df_type
 
@@ -282,7 +283,7 @@ class TestNode:
         assert df.loc[0, "c1_group1_t1"] == "t0 group_1_t1"
         assert df.loc[0, "c1_group2_t1"] == "t0 group_2_t1"
 
-    def test_run_dataframe_conversion(self, spark):
+    def test_run_dataframe_conversion(self, spark_view):
         """
         If a node is dependant upon a node of a different dataframe type, then we expect the output of the parent node
         to be converted when it's provided to the child node.
@@ -290,7 +291,7 @@ class TestNode:
 
         @node(type="pandas_on_spark", output=Schema([Column("c1", Decimal(10, 2))]))
         def t1():
-            return spark.createDataFrame(
+            return spark_view.createDataFrame(
                 pd.DataFrame(data={"c1": [1], "c2": [2], "c3": [3]})
             ).pandas_api()
 
@@ -298,8 +299,8 @@ class TestNode:
         def t2(t1):
             return t1
 
-        t1_output = t1.run(spark, parallel=False)
-        t2_output = t2.run(spark, parallel=False)
+        t1_output = t1.run(spark_view, parallel=False)
+        t2_output = t2.run(spark_view, parallel=False)
         assert isinstance(t1_output, ps.frame.DataFrame)
         assert isinstance(t2_output, pd.DataFrame)
 
@@ -355,7 +356,7 @@ class TestNode:
 
         t3.run(parallel=False)
 
-    def test_adhoc_call(self, spark):
+    def test_adhoc_call(self, spark_view):
         """
         If we call a node directly with a function call we should skip calling the input dependencies and instead use
         the passed in arguments
@@ -382,8 +383,8 @@ class TestNode:
         def t2(t1):
             return t1.withColumn("c1", t1.c1 + 1)
 
-        df = spark.createDataFrame(schema=("c1",), data=[(1,)])
-        expected_df = spark.createDataFrame(schema=("c1",), data=[(2,)])
+        df = spark_view.createDataFrame(schema=("c1",), data=[(1,)])
+        expected_df = spark_view.createDataFrame(schema=("c1",), data=[(2,)])
 
         assert_pyspark_df_equal(t2(df), expected_df)
 
@@ -680,7 +681,7 @@ class TestNode:
 
         t3.run(parallel=False)
 
-    def test_run_isolated_dependencies_pandas_on_spark(self, spark):
+    def test_run_isolated_dependencies_pandas_on_spark(self, spark_view):
         """
         When we pass a dataframe dependency from an ancestor node to a child node the dataframe should be completely
         isolated. That is, any changes to the input dataframe should not modify the output of the parent node.
@@ -688,7 +689,7 @@ class TestNode:
 
         @node(type="pandas_on_spark")
         def t1():
-            return spark.createDataFrame(data=[{"c1": 1}]).pandas_api()
+            return spark_view.createDataFrame(data=[{"c1": 1}]).pandas_api()
 
         @node(type="pandas_on_spark", dependencies=[t1])
         def t2(t1):
@@ -705,7 +706,7 @@ class TestNode:
 
         t3.run(parallel=False)
 
-    def test_run_isolated_dependencies_spark(self, spark):
+    def test_run_isolated_dependencies_spark(self, spark_view):
         """
         When we pass a dataframe dependency from an ancestor node to a child node the dataframe should be completely
         isolated. That is, any changes to the input dataframe should not modify the output of the parent node.
@@ -715,7 +716,7 @@ class TestNode:
             type="pyspark",
         )
         def t1():
-            return spark.createDataFrame(data=[{"c1": 1}])
+            return spark_view.createDataFrame(data=[{"c1": 1}])
 
         @node(type="pyspark", dependencies=[t1])
         def t2(t1):
@@ -732,7 +733,7 @@ class TestNode:
 
         t3.run(parallel=False)
 
-    def test_pandas_on_spark_use_pandas(self, spark):
+    def test_pandas_on_spark_use_pandas(self, spark_view):
         """
         When running a graph with pandas_on_spark_use_pandas=True, all pandas_on_spark nodes types should be of type
         pandas. If running straight after, but with pandas_on_spark_use_pandas=False, all pandas_on_spark nodes types
@@ -743,10 +744,10 @@ class TestNode:
         def t1(dummy_table1):
             return dummy_table1
 
-        t1.run(spark, pandas_on_spark_use_pandas=True)
+        t1.run(spark_view, pandas_on_spark_use_pandas=True)
         assert t1.dataframe_type == DataFrameType.PANDAS_ON_SPARK
 
-        t1.run(spark, pandas_on_spark_use_pandas=False)
+        t1.run(spark_view, pandas_on_spark_use_pandas=False)
         assert t1.dataframe_type == DataFrameType.PANDAS_ON_SPARK
 
         # TODO- we should refactor to avoid having to call this private method to build a graph
@@ -758,7 +759,7 @@ class TestNode:
                     == DataFrameType.PANDAS
                 )
 
-    def test_function_argument_signature(self, spark):
+    def test_function_argument_signature(self, spark_view):
         """
         Independent of the order of the argument that the user types for a function,
         it should be given accordingly to what has been specified in the function
@@ -778,7 +779,7 @@ class TestNode:
 
         @node(type="pyspark")
         def t1():
-            return spark.createDataFrame(data=[{"c1": 1, "c2": 2}])
+            return spark_view.createDataFrame(data=[{"c1": 1, "c2": 2}])
 
         @node(
             type="pyspark",
@@ -788,9 +789,10 @@ class TestNode:
         )
         def t2(t1, requested_columns, spark):
             assert requested_columns == ["c1"]
+            print("======>", dataframe_type(t1))
             assert dataframe_type(t1) == DataFrameType.PYSPARK
             assert t1.columns == ["c1"]
-            assert isinstance(spark, pyspark.sql.session.SparkSession)
+            assert isinstance(spark, pyspark.sql.session.SparkSession) or isinstance(spark, pyspark.sql.connect.session.SparkSession)
             return t1
 
         @node(
@@ -808,11 +810,11 @@ class TestNode:
             assert dataframe_type(t2) == DataFrameType.PYSPARK
             assert t2.columns == ["c1"]
 
-            assert isinstance(spark, pyspark.sql.session.SparkSession)
+            assert isinstance(spark, pyspark.sql.session.SparkSession) or isinstance(spark, pyspark.sql.connect.session.SparkSession)
 
             return t1
 
-        t3.run(spark, parallel=False)
+        t3.run(spark_view, parallel=False)
 
     def test_run_one_dependency_multiple_instances(self):
         """
@@ -852,11 +854,11 @@ class TestNode:
         with pytest.raises(TypeError):
             t1.run()
 
-    def test_spark_sql_conversion(self, spark):
+    def test_spark_sql_conversion(self, spark_view):
         """
-        If we use a spark sql code then:
+        If we use a spark_view sql code then:
         - any dependencies should be saved into a unique table.
-        - the dataframes passed into the spark sql function should be replaced with the names of the tables they were
+        - the dataframes passed into the spark_view sql function should be replaced with the names of the tables they were
         saved into.
         """
 
@@ -868,18 +870,20 @@ class TestNode:
         def t2(t1):
             return f"select number+1 from {t1}"
 
+        dataframe_to_mock = SqlConnectDataFrame if os.environ.get("USE_SPARK_CONNECT") == "1" else DataFrame
         with mock.patch.object(
-            DataFrame, "createOrReplaceTempView"
+            dataframe_to_mock, "createOrReplaceTempView"
         ) as createOrReplaceTempView_mock, mock.patch.object(
-            spark, "sql", return_value=spark.createDataFrame(data=[{"number": 2}])
+            spark_view, "sql", return_value=spark_view.createDataFrame(schema=("number",), data=[(2,)])
         ) as sql_mock:
-            t2.run(spark=spark)
+            t2.run(spark=spark_view)
+
         assert sql_mock.call_args[0][0] == "select number+1 from t2__t1"
         assert createOrReplaceTempView_mock.call_args[0][0] == "t2__t1"
 
-    def test_spark_sql_select_column(self, spark):
+    def test_spark_sql_select_column(self, spark_view):
         """
-        Basic test for spark sql where the dependency has a select column in it.
+        Basic test for spark_view sql where the dependency has a select column in it.
         There was a bug (DATA-3936) where this use case stacktraces.
         """
 
@@ -891,12 +895,13 @@ class TestNode:
         def t2(t1):
             return f"select * from {t1}"
 
+        dataframe_to_mock = SqlConnectDataFrame if os.environ.get("USE_SPARK_CONNECT") == "1" else DataFrame
         with mock.patch.object(
-            DataFrame, "createOrReplaceTempView"
+            dataframe_to_mock, "createOrReplaceTempView"
         ) as createOrReplaceTempView_mock, mock.patch.object(
-            spark, "sql", return_value=spark.createDataFrame(data=[{"number": 2}])
+            spark_view, "sql", return_value=spark_view.createDataFrame(data=[{"number": 2}])
         ) as sql_mock:
-            t2.run(spark=spark)
+            t2.run(spark=spark_view)
         assert sql_mock.call_args[0][0] == "select * from t2__t1"
         assert createOrReplaceTempView_mock.call_args[0][0] == "t2__t1"
 

--- a/flypipe/node_test.py
+++ b/flypipe/node_test.py
@@ -792,7 +792,9 @@ class TestNode:
             print("======>", dataframe_type(t1))
             assert dataframe_type(t1) == DataFrameType.PYSPARK
             assert t1.columns == ["c1"]
-            assert isinstance(spark, pyspark.sql.session.SparkSession) or isinstance(spark, pyspark.sql.connect.session.SparkSession)
+            assert isinstance(spark, pyspark.sql.session.SparkSession) or isinstance(
+                spark, pyspark.sql.connect.session.SparkSession
+            )
             return t1
 
         @node(
@@ -810,7 +812,9 @@ class TestNode:
             assert dataframe_type(t2) == DataFrameType.PYSPARK
             assert t2.columns == ["c1"]
 
-            assert isinstance(spark, pyspark.sql.session.SparkSession) or isinstance(spark, pyspark.sql.connect.session.SparkSession)
+            assert isinstance(spark, pyspark.sql.session.SparkSession) or isinstance(
+                spark, pyspark.sql.connect.session.SparkSession
+            )
 
             return t1
 
@@ -870,11 +874,17 @@ class TestNode:
         def t2(t1):
             return f"select number+1 from {t1}"
 
-        dataframe_to_mock = SqlConnectDataFrame if os.environ.get("USE_SPARK_CONNECT") == "1" else DataFrame
+        dataframe_to_mock = (
+            SqlConnectDataFrame
+            if os.environ.get("USE_SPARK_CONNECT") == "1"
+            else DataFrame
+        )
         with mock.patch.object(
             dataframe_to_mock, "createOrReplaceTempView"
         ) as createOrReplaceTempView_mock, mock.patch.object(
-            spark_view, "sql", return_value=spark_view.createDataFrame(schema=("number",), data=[(2,)])
+            spark_view,
+            "sql",
+            return_value=spark_view.createDataFrame(schema=("number",), data=[(2,)]),
         ) as sql_mock:
             t2.run(spark=spark_view)
 
@@ -895,11 +905,17 @@ class TestNode:
         def t2(t1):
             return f"select * from {t1}"
 
-        dataframe_to_mock = SqlConnectDataFrame if os.environ.get("USE_SPARK_CONNECT") == "1" else DataFrame
+        dataframe_to_mock = (
+            SqlConnectDataFrame
+            if os.environ.get("USE_SPARK_CONNECT") == "1"
+            else DataFrame
+        )
         with mock.patch.object(
             dataframe_to_mock, "createOrReplaceTempView"
         ) as createOrReplaceTempView_mock, mock.patch.object(
-            spark_view, "sql", return_value=spark_view.createDataFrame(data=[{"number": 2}])
+            spark_view,
+            "sql",
+            return_value=spark_view.createDataFrame(data=[{"number": 2}]),
         ) as sql_mock:
             t2.run(spark=spark_view)
         assert sql_mock.call_args[0][0] == "select * from t2__t1"

--- a/flypipe/pyspark_node_test.py
+++ b/flypipe/pyspark_node_test.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pyspark.pandas as ps
 import pyspark.sql.functions as F
 import pytest
-from pyspark_test import assert_pyspark_df_equal
+from flypipe.tests.pyspark_test import assert_pyspark_df_equal
 from tabulate import tabulate
 
 from flypipe.datasource.spark import Spark
@@ -15,8 +15,7 @@ from flypipe.schema.types import Decimal, Integer, String
 
 
 @pytest.fixture(scope="function")
-def spark():
-    from flypipe.tests.spark import spark
+def spark_view(spark):
 
     (
         spark.createDataFrame(
@@ -37,7 +36,7 @@ class TestPySparkNode:
             def dummy():
                 pass
 
-    def test_skip_datasource(self, spark, mocker):
+    def test_skip_datasource(self, spark_view, mocker):
         """
         When we provide a dependency input to a node, not only does that node not need to be run but we also expect any
         dependencies of the provided node not to be run.
@@ -60,12 +59,12 @@ class TestPySparkNode:
         # Filthy hack to stop the spy removing the __name__ attribute from the function
         spark_dummy_table.function.__name__ = func_name
 
-        df = spark.createDataFrame(schema=("c1", "c2", "c3"), data=[(1, 2, 3)])
-        output_df = t1.run(spark, inputs={Spark("dummy_table"): df}, parallel=False)
+        df = spark_view.createDataFrame(schema=("c1", "c2", "c3"), data=[(1, 2, 3)])
+        output_df = t1.run(spark_view, inputs={Spark("dummy_table"): df}, parallel=False)
         spy.assert_not_called()
         assert_pyspark_df_equal(
             output_df,
-            spark.createDataFrame(
+            spark_view.createDataFrame(
                 schema=(
                     "c1",
                     "c2",
@@ -80,8 +79,8 @@ class TestPySparkNode:
             check_dtype=False,
         )
 
-    def test_datasource_basic(self, spark):
-        stored_df = spark.createDataFrame(schema=("c1",), data=[(1,)])
+    def test_datasource_basic(self, spark_view):
+        stored_df = spark_view.createDataFrame(schema=("c1",), data=[(1,)])
 
         @node(
             type="pyspark",
@@ -91,10 +90,10 @@ class TestPySparkNode:
         def t1(dummy_table):
             return dummy_table
 
-        df = t1.run(spark, parallel=False)
+        df = t1.run(spark_view, parallel=False)
         assert_pyspark_df_equal(df, stored_df, check_dtype=False)
 
-    def test_conversion_to_pandas(self, spark):
+    def test_conversion_to_pandas(self, spark_view):
         @node(
             type="pyspark",
             dependencies=[Spark("dummy_table").select("c1")],
@@ -111,10 +110,10 @@ class TestPySparkNode:
         def t2(t1):
             return t1
 
-        df = t2.run(spark, parallel=False)
+        df = t2.run(spark_view, parallel=False)
         assert isinstance(df, pd.DataFrame)
 
-    def test_conversion_to_pandas_on_spark(self, spark):
+    def test_conversion_to_pandas_on_spark(self, spark_view):
         @node(
             type="pyspark",
             dependencies=[Spark("dummy_table").select("c1")],
@@ -131,10 +130,10 @@ class TestPySparkNode:
         def t2(t1):
             return t1
 
-        df = t2.run(spark, parallel=False)
+        df = t2.run(spark_view, parallel=False)
         assert isinstance(df, ps.DataFrame)
 
-    def test_datasource_case_sensitive_columns(self, spark):
+    def test_datasource_case_sensitive_columns(self, spark_view):
         """
         Test columns case sensitive
 
@@ -145,14 +144,14 @@ class TestPySparkNode:
         print(df['my_col']) #<-- fails
 
         Pyspark Dataframe
-        df = spark.createDataFrame(schema=('My_Col__x',), data=[(1,)])
+        df = spark_view.createDataFrame(schema=('My_Col__x',), data=[(1,)])
         df.select('My_Col__x') #<-- passes
         df.select('my_col__x') #<-- fails
 
 
         """
 
-        my_data = spark.createDataFrame(
+        my_data = spark_view.createDataFrame(
             schema=(
                 "My_Col__x",
                 "My_Col__y",
@@ -188,7 +187,7 @@ class TestPySparkNode:
             return df
 
         with pytest.raises(DataFrameMissingColumns) as exc_info:
-            my_col.run(spark, parallel=False)
+            my_col.run(spark_view, parallel=False)
 
         expected_error_df = pd.DataFrame(
             data={
@@ -210,7 +209,7 @@ class TestPySparkNode:
             f"\n\n\n{tabulate(expected_error_df, headers='keys', tablefmt='mixed_outline')}\n"
         )
 
-    def test_duplicated_output_columns(self, spark):
+    def test_duplicated_output_columns(self, spark_view):
         @node(
             type="pandas_on_spark",
             dependencies=[Spark("dummy_table").select("c1", "c2")],
@@ -250,18 +249,18 @@ class TestPySparkNode:
                 continue
             assert len(n["output_columns"]) == len(set(n["output_columns"]))
 
-        df = t4.run(spark, parallel=False)
+        df = t4.run(spark_view, parallel=False)
         assert_pyspark_df_equal(
-            df, spark.createDataFrame(schema=("c2",), data=[("2",)]), check_dtype=False
+            df, spark_view.createDataFrame(schema=("c2",), data=[("2",)]), check_dtype=False
         )
 
-    def test_dataframes_are_isolated_from_nodes(self, spark):
+    def test_dataframes_are_isolated_from_nodes(self, spark_view):
         @node(
             type="pyspark",
             output=Schema([Column("c1", String()), Column("c2", String())]),
         )
         def t1():
-            return spark.createDataFrame(pd.DataFrame(data={"c1": ["1"], "c2": ["2"]}))
+            return spark_view.createDataFrame(pd.DataFrame(data={"c1": ["1"], "c2": ["2"]}))
 
         @node(
             type="pyspark",
@@ -300,6 +299,6 @@ class TestPySparkNode:
             assert t2.loc[0, "c1"] == "t2 set this value"
             assert t2.loc[0, "c2"] == "2"
             assert t2.loc[0, "c3"] == "t2 set this value"
-            return spark.createDataFrame(t2)
+            return spark_view.createDataFrame(t2)
 
-        t3.run(spark, parallel=False)
+        t3.run(spark_view, parallel=False)

--- a/flypipe/pyspark_node_test.py
+++ b/flypipe/pyspark_node_test.py
@@ -60,7 +60,9 @@ class TestPySparkNode:
         spark_dummy_table.function.__name__ = func_name
 
         df = spark_view.createDataFrame(schema=("c1", "c2", "c3"), data=[(1, 2, 3)])
-        output_df = t1.run(spark_view, inputs={Spark("dummy_table"): df}, parallel=False)
+        output_df = t1.run(
+            spark_view, inputs={Spark("dummy_table"): df}, parallel=False
+        )
         spy.assert_not_called()
         assert_pyspark_df_equal(
             output_df,
@@ -251,7 +253,9 @@ class TestPySparkNode:
 
         df = t4.run(spark_view, parallel=False)
         assert_pyspark_df_equal(
-            df, spark_view.createDataFrame(schema=("c2",), data=[("2",)]), check_dtype=False
+            df,
+            spark_view.createDataFrame(schema=("c2",), data=[("2",)]),
+            check_dtype=False,
         )
 
     def test_dataframes_are_isolated_from_nodes(self, spark_view):
@@ -260,7 +264,9 @@ class TestPySparkNode:
             output=Schema([Column("c1", String()), Column("c2", String())]),
         )
         def t1():
-            return spark_view.createDataFrame(pd.DataFrame(data={"c1": ["1"], "c2": ["2"]}))
+            return spark_view.createDataFrame(
+                pd.DataFrame(data={"c1": ["1"], "c2": ["2"]})
+            )
 
         @node(
             type="pyspark",

--- a/flypipe/templates/catalog.html
+++ b/flypipe/templates/catalog.html
@@ -2,7 +2,7 @@
     <head>
     </head>
     <body>
-        <div id="root" style="height: {{ height }}px;"></div>
+        <div id="root" style="height: {{ height }}px !important;"></div>
         <script>
             window.nodes = {{ nodes | safe }};
             window.tagSuggestions = {{ tagSuggestions | safe }};

--- a/flypipe/tests/conftest.py
+++ b/flypipe/tests/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-
-@pytest.fixture(scope="function")
-def spark():
-    # Put the import locally otherwise it will shadow this identically named function
-    from flypipe.tests.spark import spark
-
-    return spark

--- a/flypipe/tests/pyspark_test.py
+++ b/flypipe/tests/pyspark_test.py
@@ -1,0 +1,116 @@
+from typing import Any, Union, List
+
+import pyspark
+
+def _check_isinstance_pyspark(df: Any, clss):
+
+    for cls in clss:
+        if isinstance(df, cls):
+            return True
+
+    return False
+
+def _check_isinstance(left: Any, right: Any, cls: List[Any]):
+    if not _check_isinstance_pyspark(left, cls):
+        raise TypeError(f"Left expected type {cls}, found {type(left)} instead")
+
+    if not _check_isinstance_pyspark(left, cls):
+        raise TypeError(f"Right expected type {cls}, found {type(rigght)} instead")
+
+
+def _check_columns(
+    check_columns_in_order: bool,
+    left_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    right_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+):
+    if check_columns_in_order:
+        assert left_df.columns == right_df.columns, "df columns name mismatch"
+    else:
+        assert sorted(left_df.columns) == sorted(
+            right_df.columns
+        ), "df columns name mismatch"
+
+
+def _check_schema(
+    check_columns_in_order: bool,
+    left_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    right_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+):
+    if check_columns_in_order:
+        assert left_df.dtypes == right_df.dtypes, "df schema type mismatch"
+    else:
+        assert sorted(left_df.dtypes, key=lambda x: x[0]) == sorted(
+            right_df.dtypes, key=lambda x: x[0]
+        ), "df schema type mismatch"
+
+
+def _check_df_content(
+    left_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame], right_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+):
+    left_df_list = left_df.collect()
+    right_df_list = right_df.collect()
+
+    for row_index in range(len(left_df_list)):
+        for column_name in left_df.columns:
+            left_cell = left_df_list[row_index][column_name]
+            right_cell = right_df_list[row_index][column_name]
+            if left_cell == right_cell:
+                assert True
+            elif left_cell is None and right_cell is None:
+                assert True
+            # elif math.isnan(left_cell) and math.isnan(right_cell):
+            #     assert True
+            else:
+                msg = f"Data mismatch\n\nRow = {row_index + 1} : Column = {column_name}\n\nACTUAL: {left_cell}\nEXPECTED: {right_cell}\n"
+                assert False, msg
+
+
+def _check_row_count(left_df, right_df):
+    left_df_count = left_df.count()
+    right_df_count = right_df.count()
+    assert (
+        left_df_count == right_df_count
+    ), f"Number of rows are not same.\n\nActual Rows: {left_df_count}\nExpected Rows: {right_df_count}\n"
+
+
+def assert_pyspark_df_equal(
+    left_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    right_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    check_dtype: bool = True,
+    check_column_names: bool = False,
+    check_columns_in_order: bool = False,
+    order_by: list = None,
+) -> None:
+    """
+    Used to test if two dataframes are same or not
+
+    Args:
+        left_df (Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame]): Left Dataframe
+        right_df (Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame]): Right Dataframe
+        check_dtype (bool, optional): Comapred both dataframe have same column and colum type or not. If using check_dtype then check_column_names is not required. Defaults to True.
+        check_column_names (bool, optional): Comapare both dataframes have same column or not. Defaults to False.
+        check_columns_in_order (bool, optional): Check columns in order. Defaults to False.
+        order_by (list, optional): List of column names if we want to sort dataframe before comparing. Defaults to None.
+    """
+
+    # Check if
+    _check_isinstance(left_df, right_df, [pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame])
+
+    # Check Column Names
+    if check_column_names:
+        _check_columns(check_columns_in_order, left_df, right_df)
+
+    # Check Column Data Types
+    if check_dtype:
+        _check_schema(check_columns_in_order, left_df, right_df)
+
+    # Check number of rows
+    _check_row_count(left_df, right_df)
+
+    # Sort df
+    if order_by:
+        left_df = left_df.orderBy(order_by)
+        right_df = right_df.orderBy(order_by)
+
+    # Check dataframe content
+    _check_df_content(left_df, right_df)

--- a/flypipe/tests/pyspark_test.py
+++ b/flypipe/tests/pyspark_test.py
@@ -2,6 +2,7 @@ from typing import Any, Union, List
 
 import pyspark
 
+
 def _check_isinstance_pyspark(df: Any, clss):
 
     for cls in clss:
@@ -10,12 +11,13 @@ def _check_isinstance_pyspark(df: Any, clss):
 
     return False
 
+
 def _check_isinstance(left: Any, right: Any, cls: List[Any]):
     if not _check_isinstance_pyspark(left, cls):
         raise TypeError(f"Left expected type {cls}, found {type(left)} instead")
 
-    if not _check_isinstance_pyspark(left, cls):
-        raise TypeError(f"Right expected type {cls}, found {type(rigght)} instead")
+    if not _check_isinstance_pyspark(right, cls):
+        raise TypeError(f"Right expected type {cls}, found {type(right)} instead")
 
 
 def _check_columns(
@@ -45,7 +47,8 @@ def _check_schema(
 
 
 def _check_df_content(
-    left_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame], right_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    left_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    right_df: Union[pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
 ):
     left_df_list = left_df.collect()
     right_df_list = right_df.collect()
@@ -94,7 +97,11 @@ def assert_pyspark_df_equal(
     """
 
     # Check if
-    _check_isinstance(left_df, right_df, [pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame])
+    _check_isinstance(
+        left_df,
+        right_df,
+        [pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame],
+    )
 
     # Check Column Names
     if check_column_names:

--- a/flypipe/tests/spark.py
+++ b/flypipe/tests/spark.py
@@ -1,25 +1,35 @@
 import os
-
+from uuid import uuid4
 from pyspark.sql import SparkSession
 
 # Avoid WARNING:root:'PYARROW_IGNORE_TIMEZONE' environment variable was not set
 os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
 
-
 def build_spark():
-    configs = (
-        SparkSession.builder.appName("flypipe")
+    if os.environ.get("USE_SPARK_CONNECT") == "1":
+        print(f"Building spark session (spark_connect)")
+
+        return (
+            SparkSession.builder.appName(str(uuid4()))
+            .remote("sc://spark-connect:15002")
+            .config("spark.sql.repl.eagerEval.enabled", "true")
+            .config("spark.sql.execution.arrow.pyspark.enabled", "true")
+            .getOrCreate()
+        )
+
+    print(f"Building spark session")
+
+    spark = (
+        SparkSession.builder.appName(str(uuid4()))
         .master("local[1]")
+        .config("spark.driver.host", "localhost")
         .config("spark.submit.deployMode", "client")
         .config("spark.ui.enabled", "false")
         .config("spark.ui.liveUpdate.period", "-1")
         .config("spark.sql.repl.eagerEval.enabled", "true")
         .config("spark.sql.execution.arrow.pyspark.enabled", "true")
+        .getOrCreate()
     )
 
-    spark = configs.getOrCreate()
     spark.sparkContext.setLogLevel("ERROR")
     return spark
-
-
-spark = build_spark()

--- a/flypipe/tests/spark.py
+++ b/flypipe/tests/spark.py
@@ -5,9 +5,10 @@ from pyspark.sql import SparkSession
 # Avoid WARNING:root:'PYARROW_IGNORE_TIMEZONE' environment variable was not set
 os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
 
+
 def build_spark():
     if os.environ.get("USE_SPARK_CONNECT") == "1":
-        print(f"Building spark session (spark_connect)")
+        print("Building spark session (spark_connect)")
 
         return (
             SparkSession.builder.appName(str(uuid4()))
@@ -17,7 +18,7 @@ def build_spark():
             .getOrCreate()
         )
 
-    print(f"Building spark session")
+    print("Building spark session")
 
     spark = (
         SparkSession.builder.appName(str(uuid4()))

--- a/flypipe/utils.py
+++ b/flypipe/utils.py
@@ -4,6 +4,7 @@ from enum import Enum
 import pandas as pd
 import pyspark.pandas as ps
 import pyspark.sql.dataframe as sql
+import pyspark.sql.connect.dataframe as sql_connect
 from pandas.testing import assert_frame_equal
 
 from flypipe.exceptions import (
@@ -62,7 +63,7 @@ def dataframe_type(df) -> DataFrameType:
         return DataFrameType.PANDAS
     if isinstance(df, ps.DataFrame):
         return DataFrameType.PANDAS_ON_SPARK
-    if isinstance(df, sql.DataFrame):
+    if isinstance(df, sql.DataFrame) or isinstance(df, sql_connect.DataFrame):
         return DataFrameType.PYSPARK
     raise DataframeTypeNotSupportedError(type(df))
 

--- a/flypipe/utils_test.py
+++ b/flypipe/utils_test.py
@@ -13,7 +13,6 @@ from flypipe.utils import assert_dataframes_equals, DataFrameType, dataframe_typ
 class TestUtils:
     """Tests on Utils"""
 
-    @pytest.mark.skip("Test succeeds locally but fails on GitHub")
     def test_assert_dataframes_equals(self, spark):
         df1 = spark.createDataFrame(
             pd.DataFrame(data={"col1": [1, 2], "col2": ["1a", "2a"]})

--- a/frontend/styles/styles.scss
+++ b/frontend/styles/styles.scss
@@ -57,7 +57,8 @@ html {
 }
 
 .list-group-flypipe {
-    height: calc(100vh - 100px);
+    // can not use height: calc(100vh - 100px); it breaks in mac users
+    height: 100%;
 }
 
 .search {

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim
 
-RUN apt-get update && apt-get install -y apt-utils default-jdk curl wget graphviz -y
+RUN apt-get update && apt-get install -y apt-utils build-essential default-jdk curl wget graphviz man-db
 RUN pip install --upgrade pip
 COPY ./requirements.txt .
 COPY ./local/requirements.txt requirements_dev.txt
@@ -20,6 +20,12 @@ ENV PATH "${PATH}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin"
 ENV PYSPARK_PYTHON "/usr/local/bin/python3"
 ENV PYSPARK_DRIVER_PYTHON "${PYSPARK_PYTHON}"
 ENV USE_SPARK_CONNECT "0"
+
+## Set up Pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-1-arm64.deb
+RUN dpkg -i pandoc-3.6.2-1-arm64.deb
+## Check installation
+RUN pandoc -v
 
 COPY /flypipe /flypipe
 ENV PYTHONPATH "${PYTHONPATH}:/local:/flypipe:/:"

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -21,9 +21,10 @@ ENV PYSPARK_PYTHON "/usr/local/bin/python3"
 ENV PYSPARK_DRIVER_PYTHON "${PYSPARK_PYTHON}"
 ENV USE_SPARK_CONNECT "0"
 
+
 ## Set up Pandoc
-RUN wget https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-1-arm64.deb
-RUN dpkg -i pandoc-3.6.2-1-arm64.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-1-`dpkg --print-architecture`.deb
+RUN dpkg -i pandoc-3.6.2-1-`dpkg --print-architecture`.deb
 ## Check installation
 RUN pandoc -v
 

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -9,15 +9,17 @@ RUN pip install -r requirements.txt
 RUN pip install -r requirements_dev.txt
 
 WORKDIR .
-RUN wget https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3-scala2.13.tgz
-RUN tar xf spark-*
-RUN mv spark-3.3.2-bin-hadoop3-scala2.13 /opt/spark
+RUN wget https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz
+RUN tar xf spark-* && \
+    mv spark-3.5.4-bin-hadoop3 /opt/spark && \
+    rm spark-*.tgz
 
 ENV SPARK_HOME "/opt/spark"
 ENV HADOOP_HOME "${SPARK_HOME}"
 ENV PATH "${PATH}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin"
 ENV PYSPARK_PYTHON "/usr/local/bin/python3"
 ENV PYSPARK_DRIVER_PYTHON "${PYSPARK_PYTHON}"
+ENV USE_SPARK_CONNECT "0"
 
 COPY /flypipe /flypipe
 ENV PYTHONPATH "${PYTHONPATH}:/local:/flypipe:/:"

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -1,5 +1,33 @@
-version: '3.9'
 services:
+  spark-master:
+    image: bitnami/spark:3.5.4
+    container_name: spark-master
+    environment:
+      - SPARK_MODE=master
+      - SPARK_MASTER_WEBUI_PORT=8080
+      - SPARK_MASTER_PORT=7077
+      - SPARK_SUBMIT_OPTIONS=--packages io.delta:delta-spark_2.12:3.3.0
+      - SPARK_MASTER_HOST=spark-master
+    ports:
+      - 8080:8080
+      - 7077:7077
+    networks:
+      - flypipe-ntw
+
+  spark-connect:
+    image: bitnami/spark:3.5.4
+    container_name: spark-connect
+    environment:
+      - SPARK_MODE=driver
+      - SPARK_MASTER=spark://spark-master:7077
+    ports:
+      - 15002:15002
+    depends_on:
+      - spark-master
+    networks:
+      - flypipe-ntw
+    command: [ "/bin/bash", "-c", "/opt/bitnami/spark/sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.4" ]
+
   flypipe-mariadb:
     image: mariadb:10.11.4
     ports:
@@ -9,6 +37,8 @@ services:
       MYSQL_USER: admin
       MYSQL_PASSWORD: admin
       MYSQL_DATABASE: metastore_db
+    networks:
+      - flypipe-ntw
 
   flypipe-hive-metastore:
     build:
@@ -16,10 +46,10 @@ services:
       dockerfile: ./hive/Dockerfile
     ports:
       - 9083:9083
-    volumes:
-      - ./data/metastore:/data
     depends_on:
       - flypipe-mariadb
+    networks:
+      - flypipe-ntw
     entrypoint: sh -c './../entrypoint.sh'
 
   flypipe-jupyter:
@@ -37,8 +67,11 @@ services:
       - ../flypipe:/flypipe
       - ./start.py:/etc/ipython/startup/start.py
       - ../docs/source/notebooks:/notebooks/docs
-      - ./data:/data
       - ./wait-for-it.sh:/wait-for-it.sh
+    depends_on:
+      - spark-connect
+    networks:
+      - flypipe-ntw
     entrypoint: sh -c 'jupyter-lab --notebook-dir /notebooks --allow-root --no-browser --port 8888 --ip 0.0.0.0  --NotebookApp.token="" --NotebookApp.password=""'
 
   flypipe-test:
@@ -48,3 +81,8 @@ services:
     container_name: flypipe-test
     environment:
       FLYPIPE_DEFAULT_RUN_MODE: sequential
+    networks:
+      - flypipe-ntw
+
+networks:
+  flypipe-ntw:

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -65,6 +65,8 @@ services:
     volumes:
       - ../.pylintrc:/.pylintrc
       - ../flypipe:/flypipe
+      - ../scripts:/scripts
+      - ../docs:/docs
       - ./start.py:/etc/ipython/startup/start.py
       - ../docs/source/notebooks:/notebooks/docs
       - ./wait-for-it.sh:/wait-for-it.sh

--- a/local/requirements.txt
+++ b/local/requirements.txt
@@ -31,8 +31,10 @@ gitpython==3.1.43
 jupyterlab==4.2.4
 pythonping==1.1.4
 ipytest==0.14.2
-delta-spark==2.1.1
-mlflow==2.0.1
+delta-spark==3.3.0
+mlflow
 matplotlib==3.6.2
 seaborn==0.12.1
 scipy==1.7.3
+grpcio==1.70.0
+grpcio-status==1.70.0

--- a/local/requirements.txt
+++ b/local/requirements.txt
@@ -32,7 +32,7 @@ jupyterlab==4.2.4
 pythonping==1.1.4
 ipytest==0.14.2
 delta-spark==3.3.0
-mlflow
+mlflow==2.20.1
 matplotlib==3.6.2
 seaborn==0.12.1
 scipy==1.7.3

--- a/local/requirements.txt
+++ b/local/requirements.txt
@@ -32,7 +32,7 @@ jupyterlab==4.2.4
 pythonping==1.1.4
 ipytest==0.14.2
 delta-spark==3.3.0
-mlflow==2.20.1
+mlflow==2.17.2
 matplotlib==3.6.2
 seaborn==0.12.1
 scipy==1.7.3

--- a/local/requirements.txt
+++ b/local/requirements.txt
@@ -32,7 +32,7 @@ jupyterlab==4.2.4
 pythonping==1.1.4
 ipytest==0.14.2
 delta-spark==3.3.0
-mlflow==2.17.2
+mlflow==2.20.1
 matplotlib==3.6.2
 seaborn==0.12.1
 scipy==1.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Jinja2==3.1.4
 tabulate==0.9.0
 numpy==1.22.2
 pandas==1.4.2
-pyspark[sql,pandas_on_spark]==3.3.2
+pyspark[sql,pandas_on_spark]==3.5.4


### PR DESCRIPTION
New feature [Add support to pyspark.sql.connect.dataframe.DataFrame ](https://github.com/flypipe/flypipe/issues/148).

This PR adds a new support to pyspark.sql.connect.dataframe.DataFrame.

Spark released [Spark Connect](https://spark.apache.org/spark-connect/) that allows users to connect via a connection established between the Client and Spark Server.

When connection to a Spark Server, all spark dataframes becomes of type  `pyspark.sql.connect.dataframe` instead of `pyspark.sql.dataframe`, depending on the type of the spark context created.

To add support to `pyspark.sql.connect.dataframe` in flypipe, the only change necessary is in [flypipe/utils.py](https://github.com/flypipe/flypipe/pull/154/files#diff-80d15de742506a2fa6e55606d65bbe4445bbdf2fd5d767bb1160a9f6fe36cd3a).

Most of the changes of these PR is to add a new `spark server` docker image in [local/docker-compose.yaml](https://github.com/flypipe/flypipe/pull/154/files#diff-bd6d9993f226975c4a5f75139da4cc8ff3654e9fb248f5cb52249e0372220b85) and update the [local/Dockerfile](https://github.com/flypipe/flypipe/pull/154/files#diff-5238405fb30212dc3a8f6f5323c2364c558627b01163b068dc38ade2161fb6b0) to use spark version 3.5.4

Unfortunately we are not able to run the tests for both spark and spark connect sessions in the same GitActions step because the tests are running in parallel, PySpark throws an exception forbidding having Spark and Spark Connections sessions active, the approach used to avoid this problem is to run the tests twice (see [.github/workflows/verification.yml](.github/workflows/verification.yml))

The command `make coverage USE_SPARK_CONNECT=0` will run the tests using non spark connect, and `make coverage USE_SPARK_CONNECT=1` will use spark connect for all tests. These commands will export a environment variable `export USE_SPARK_CONNECT=$(USE_SPARK_CONNECT)` defined in [Makefile](https://github.com/flypipe/flypipe/blob/41a46ecb9511c1d38f649e814117123151b157ed/Makefile#L40) that will be used to create a spark session accordingly, defined in [flypipe/tests/spark.py](https://github.com/flypipe/flypipe/pull/154/files#diff-bf93681344194914061b41a260fc93a7b4e1c5d654345a5d7f44029e20e0c3be). This approach allow us to run all tests by providing spark session using spark sql connect or not.

There are other changes in test files such as:
- `assert_pyspark_df_equal` fails because it has no support to spark sql connect and there is a PR to update the package to [include spark connect dataframes](https://github.com/debugger24/pyspark-test/pull/15), but looks like it is not been supported anymore, so a new file `flypipe/tests/pyspark_test.py` has been added with support to spark connect and all imports `from pyspark_test import assert_pyspark_df_equal` have been changed to `from flypipe.tests.pyspark_test import assert_pyspark_df_equal`
- **most of the changes in tests files** are because the test files have been importing `from flypipe.tests.conftest import spark`, these imports have been removed a a spark fisture have been added to `flypipe/conftest.py`, the file [flypipe/converter/dataframe_test.py](https://github.com/flypipe/flypipe/pull/154/files#diff-b19ff183feae907ce98bcc9e0c486fc2bc10d803adf11a4979dcb06f8c5bfd90) is a good example of these changes.
