### PR TITLE
fix(frontend): interactable fields in node view mode

### DIFF
--- a/frontend/src/graph/edit-node.jsx
+++ b/frontend/src/graph/edit-node.jsx
@@ -179,49 +179,49 @@ export const EditNode = ({
                                     style={{ height: "120px" }}
                                 />
                             </Form.Group>
-                            </fieldset>
+                        </fieldset>
 
-                            <Form.Group className="mb-3">
-                                <Form.Label className="fw-semibold">
-                                    Predecessors
-                                </Form.Label>
-                                {formState.values.predecessors.length > 0 ? (
-                                    <NodeList
-                                        nodeIds={formState.values.predecessors}
+                        <Form.Group className="mb-3">
+                            <Form.Label className="fw-semibold">
+                                Predecessors
+                            </Form.Label>
+                            {formState.values.predecessors.length > 0 ? (
+                                <NodeList
+                                    nodeIds={formState.values.predecessors}
+                                />
+                            ) : (
+                                <p>No predecessors</p>
+                            )}
+                        </Form.Group>
+
+                        <Form.Group className="mb-3">
+                            <Form.Label className="fw-semibold">
+                                Successors
+                            </Form.Label>
+                            {formState.values.successors.length > 0 ? (
+                                <NodeList
+                                    nodeIds={formState.values.successors}
+                                />
+                            ) : (
+                                <p>No successors</p>
+                            )}
+                        </Form.Group>
+
+                        <Form.Group className="mb-3">
+                            <Form.Label className="fw-semibold">
+                                Output Schema
+                            </Form.Label>
+                            {formState.values.output &&
+                                formState.values.output.length > 0 && (
+                                    <NodeOutput
+                                        output={formState.values.output}
                                     />
-                                ) : (
-                                    <p>No predecessors</p>
                                 )}
-                            </Form.Group>
-
-                            <Form.Group className="mb-3">
-                                <Form.Label className="fw-semibold">
-                                    Successors
-                                </Form.Label>
-                                {formState.values.successors.length > 0 ? (
-                                    <NodeList
-                                        nodeIds={formState.values.successors}
-                                    />
-                                ) : (
-                                    <p>No successors</p>
-                                )}
-                            </Form.Group>
-
-                            <Form.Group className="mb-3">
-                                <Form.Label className="fw-semibold">
-                                    Output Schema
-                                </Form.Label>
-                                {formState.values.output &&
-                                    formState.values.output.length > 0 && (
-                                        <NodeOutput
-                                            output={formState.values.output}
-                                        />
-                                    )}
-                                {(!formState.values.output ||
-                                    formState.values.output.length == 0) && (
-                                    <p>No output declared</p>
-                                )}
-                            </Form.Group>
+                            {(!formState.values.output ||
+                                formState.values.output.length == 0) && (
+                                <p>No output declared</p>
+                            )}
+                        </Form.Group>
 
                         <Row>
                             <Col>

--- a/frontend/src/graph/edit-node.jsx
+++ b/frontend/src/graph/edit-node.jsx
@@ -179,6 +179,7 @@ export const EditNode = ({
                                     style={{ height: "120px" }}
                                 />
                             </Form.Group>
+                            </fieldset>
 
                             <Form.Group className="mb-3">
                                 <Form.Label className="fw-semibold">
@@ -221,7 +222,6 @@ export const EditNode = ({
                                     <p>No output declared</p>
                                 )}
                             </Form.Group>
-                        </fieldset>
 
                         <Row>
                             <Col>


### PR DESCRIPTION
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
</tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/c7f95f09-8a09-405d-af12-6be5c4dd2785"></td>
    <td><img src="https://github.com/user-attachments/assets/1770554f-61c0-417f-9546-891938ecf8ac"></td>
</tr>
</table>

Since `<fieldset disabled=true>` encapsulated interactable read-only fields like `<NodeOutput>`, interactions with them were blocked. The `Accordion` was not working correctly. 
