### PR TITLE
#207-bug-when-inporting-a-column-from-another-node-colum-it-is-not-setting-pk-to-false Refactor schema reset logic to include PK handling…

### DIFF
--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -99,7 +99,7 @@ class Node:
     @property
     def output(self):
         schema = self.output_schema.copy()
-        schema.reset_relationships()
+        schema.reset(relationships=True, pk=True)
         return schema
 
     def _get_input_nodes(self, dependencies):

--- a/flypipe/schema/column.py
+++ b/flypipe/schema/column.py
@@ -94,11 +94,19 @@ class Column:
     def _set_parent(self, parent: "Node"):
         self.parent = parent
 
-    def _set_relationships(self, relationships: dict):
-        self.relationships = relationships
+    def _set_relationships(self, relationships: dict = None, reset: bool = False):
+        relationships = relationships or {}
+        self.relationships = {} if reset else relationships
 
     def reset_relationships(self):
-        self.relationships = {}
+        self._set_relationships(reset=True)
+
+    def set_pk(self, pk: bool) -> "Column":
+        self.pk = pk
+        return self
+
+    def reset_pk(self):
+        self.set_pk(False)
 
     def copy(self):
         col = Column(self.name, self.type, description=self.description, pk=self.pk)

--- a/flypipe/schema/schema.py
+++ b/flypipe/schema/schema.py
@@ -25,9 +25,13 @@ class Schema:
         for col in self.columns:
             setattr(self, col.name, col)
 
-    def reset_relationships(self):
+    def reset(self, *, relationships=True, pk=True):
         for col in self.columns:
-            col.reset_relationships()
+            if relationships:
+                col.reset_relationships()
+
+            if pk:
+                col.reset_pk()
 
     def set_parents(self, parent: "Node"):
         for col in self.columns:


### PR DESCRIPTION
Expanded the `reset` method in `Schema` to handle both relationships and primary keys (PKs). Updated `Column` methods to support resetting and setting PKs, improving flexibility. Adjusted tests to validate proper PK and relationship reset behavior.