### PR TITLE
fix(spark): casts fallback to null in spark v4

### DIFF
--- a/flypipe/dataframe/pandas_on_spark_dataframe_wrapper.py
+++ b/flypipe/dataframe/pandas_on_spark_dataframe_wrapper.py
@@ -32,7 +32,9 @@ class PandasOnSparkDataFrameWrapper(SparkDataFrameWrapper):
 
     def _cast_column(self, column, flypipe_type, df_type):
         spark_df = self.df.to_spark()
-        spark_df = spark_df.withColumn(column, spark_df[column].cast(df_type))
+        col = spark_df[column]
+        result = self._try_cast_col(col, column, df_type)
+        spark_df = spark_df.withColumn(column, result)
         self.df = spark_df.pandas_api()
 
     def _cast_column_decimal(self, column, flypipe_type):
@@ -40,19 +42,31 @@ class PandasOnSparkDataFrameWrapper(SparkDataFrameWrapper):
         df_type = DecimalType(
             precision=flypipe_type.precision, scale=flypipe_type.scale
         )
-        spark_df = spark_df.withColumn(column, spark_df[column].cast(df_type))
+        col = spark_df[column]
+        result = self._try_cast_col(col, column, df_type)
+        spark_df = spark_df.withColumn(column, result)
         self.df = spark_df.pandas_api()
 
     def _cast_column_date(self, column, flypipe_type):
         spark_df = self.df.to_spark()
-        spark_df = spark_df.withColumn(
-            column, F.to_date(F.col(column), flypipe_type.python_format)
+        date_col = F.col(column)
+        fmt = flypipe_type.pyspark_format
+        result = (
+            F.try_to_date(date_col, fmt)
+            if hasattr(F, "try_to_date")
+            else F.to_date(date_col, fmt)
         )
+        spark_df = spark_df.withColumn(column, result)
         self.df = spark_df.pandas_api()
 
     def _cast_column_datetime(self, column, flypipe_type):
         spark_df = self.df.to_spark()
-        spark_df = spark_df.withColumn(
-            column, F.to_date(F.col(column), flypipe_type.python_format)
+        ts_col = F.col(column)
+        fmt = flypipe_type.pyspark_format
+        result = (
+            F.try_to_timestamp(ts_col, fmt)
+            if hasattr(F, "try_to_timestamp")
+            else F.to_timestamp(ts_col, fmt)
         )
+        spark_df = spark_df.withColumn(column, result)
         self.df = spark_df.pandas_api()

--- a/flypipe/dataframe/spark_dataframe_wrapper.py
+++ b/flypipe/dataframe/spark_dataframe_wrapper.py
@@ -1,36 +1,36 @@
 import pyspark.sql.functions as F
 from pyspark.sql.types import (
+    BinaryType,
     BooleanType,
     ByteType,
-    BinaryType,
-    IntegerType,
-    ShortType,
-    LongType,
-    FloatType,
-    DoubleType,
-    StringType,
-    DecimalType,
     DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    ShortType,
+    StringType,
     TimestampType,
 )
 
 from flypipe.dataframe.dataframe_wrapper import DataFrameWrapper
 from flypipe.exceptions import DataFrameMissingColumns
 from flypipe.schema.types import (
-    Type,
+    Binary,
     Boolean,
     Byte,
-    Binary,
-    Integer,
-    Short,
-    Long,
-    Float,
-    Double,
-    String,
-    Unknown,
     Date,
     DateTime,
     Decimal,
+    Double,
+    Float,
+    Integer,
+    Long,
+    Short,
+    String,
+    Type,
+    Unknown,
 )
 from flypipe.utils import DataFrameType
 
@@ -102,20 +102,40 @@ class SparkDataFrameWrapper(DataFrameWrapper):
         return flypipe_type
 
     def _cast_column(self, column: str, flypipe_type: Type, df_type):
-        self.df = self.df.withColumn(column, self.df[column].cast(df_type))
+        col = self.df[column]
+        result = self._try_cast_col(col, column, df_type)
+        self.df = self.df.withColumn(column, result)
+
+    def _try_cast_col(self, col, column: str, df_type):
+        """Use try_cast (null on error). Uses Column.try_cast on Spark 4+, F.expr on Spark 3.x."""
+        try_cast_method = getattr(col, "try_cast", None)
+        if callable(try_cast_method):
+            return try_cast_method(df_type)
+        type_str = df_type.simpleString()
+        return F.expr(f"try_cast(`{column}` AS {type_str})")
 
     def _cast_column_decimal(self, column, flypipe_type):
         df_type = DecimalType(
             precision=flypipe_type.precision, scale=flypipe_type.scale
         )
-        self.df = self.df.withColumn(column, self.df[column].cast(df_type))
+        col = self.df[column]
+        result = self._try_cast_col(col, column, df_type)
+        self.df = self.df.withColumn(column, result)
 
     def _cast_column_date(self, column, flypipe_type):
-        self.df = self.df.withColumn(
-            column, F.to_date(F.col(column), flypipe_type.pyspark_format)
-        )
+        date_col = F.col(column)
+        fmt = flypipe_type.pyspark_format
+        if hasattr(F, "try_to_date"):
+            result = F.try_to_date(date_col, fmt)
+        else:
+            result = F.to_date(date_col, fmt)
+        self.df = self.df.withColumn(column, result)
 
     def _cast_column_datetime(self, column, flypipe_type):
-        self.df = self.df.withColumn(
-            column, F.to_timestamp(F.col(column), flypipe_type.pyspark_format)
-        )
+        ts_col = F.col(column)
+        fmt = flypipe_type.pyspark_format
+        if hasattr(F, "try_to_timestamp"):
+            result = F.try_to_timestamp(ts_col, fmt)
+        else:
+            result = F.to_timestamp(ts_col, fmt)
+        self.df = self.df.withColumn(column, result)

--- a/flypipe/dataframe/spark_dataframe_wrapper_test.py
+++ b/flypipe/dataframe/spark_dataframe_wrapper_test.py
@@ -1,38 +1,38 @@
 import pytest
 from pyspark.sql.types import (
-    StructType,
-    StructField,
+    BinaryType,
     BooleanType,
     ByteType,
-    BinaryType,
-    IntegerType,
-    ShortType,
-    LongType,
-    FloatType,
-    DoubleType,
-    StringType,
-    DecimalType,
-    TimestampType,
     DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    ShortType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
 )
-from flypipe.tests.pyspark_test import assert_pyspark_df_equal
 
 from flypipe.dataframe.dataframe_wrapper import DataFrameWrapper
 from flypipe.exceptions import DataFrameMissingColumns
 from flypipe.schema.types import (
-    Boolean,
-    Decimal,
-    Byte,
     Binary,
-    Integer,
-    Short,
-    Long,
-    Float,
-    Double,
-    String,
-    DateTime,
+    Boolean,
+    Byte,
     Date,
+    DateTime,
+    Decimal,
+    Double,
+    Float,
+    Integer,
+    Long,
+    Short,
+    String,
 )
+from flypipe.tests.pyspark_test import assert_pyspark_df_equal
 
 
 class TestSparkDataFrameWrapper:
@@ -151,3 +151,31 @@ class TestSparkDataFrameWrapper:
         # TODO: this is broken
         # assert_frame_equal(
         #     df_wrapper.df.toPandas(), pd.DataFrame({'col1': [None, 999.11, 1.23, None]}, dtype=np.dtype('O')))
+
+    def test_cast_column_with_column_object(self, spark):
+        """cast_column accepts Column object (e.g. from node output schema)."""
+        df = spark.createDataFrame(schema=("col1",), data=[(1,), (0,), (None,)])
+        df_wrapper = DataFrameWrapper.get_instance(spark, df)
+        df_wrapper.cast_column("col1", Boolean())
+        assert df_wrapper.df.dtypes[0] == ("col1", "boolean")
+
+    def test_cast_column_try_cast_returns_null_on_invalid(self, spark):
+        """Invalid cast values become NULL via try_cast (Flypipe always uses try_cast)."""
+        df = spark.createDataFrame(schema=("col1",), data=[("123",), ("abc",), (None,)])
+        df_wrapper = DataFrameWrapper.get_instance(spark, df)
+        df_wrapper.cast_column("col1", Long())
+        rows = [row.col1 for row in df_wrapper.df.collect()]
+        assert rows[0] == 123
+        assert rows[1] is None  # "abc" cannot cast to Long, try_cast returns NULL
+        assert rows[2] is None
+
+    def test_cast_column_with_spaces_in_name(self, spark):
+        """Columns with spaces in name work with try_cast (F.expr fallback on Spark 3.x)."""
+        schema = StructType([StructField("col name", StringType())])
+        df = spark.createDataFrame(schema=schema, data=[("123",), ("456",), (None,)])
+        df_wrapper = DataFrameWrapper.get_instance(spark, df)
+        df_wrapper.cast_column("col name", Long())
+        rows = [row["col name"] for row in df_wrapper.df.collect()]
+        assert rows[0] == 123
+        assert rows[1] == 456
+        assert rows[2] is None


### PR DESCRIPTION
### Summary

Fix Flypipe always to have a `try_cast` behavior when applying schema to Spark dataframes. So in Spark V4, invalid cast values produce `NULL` instead of raising, so the behavior is consistent across Spark v3 and Spark v4.

### Spark ANSI: v3 vs v4 behavior

**Spark v3 (and Databricks Runtime < 17)**

- `cast()` returns `NULL` when a value cannot be cast (e.g. `cast('abc' AS bigint)` → `NULL`).
- Behavior may depend on `spark.sql.ansi.enabled`.

**Spark v4 (and Databricks Runtime 17+)**

- With ANSI mode enabled by default, `cast()` throws on invalid values instead of returning `NULL`.
- Pipelines that rely on NULL on invalid casts can break.

**try_cast**

- `try_cast()` returns `NULL` on failure regardless of ANSI mode.
- Spark 3.2+: `try_cast()` via SQL (e.g. `F.expr`).
- Spark 4+: also exposed as `Column.try_cast()`.

### Changes

- **Spark / Pandas-on-Spark**: Always use `try_cast` for schema casting:
  - Numeric types: `Column.try_cast()` when available (Spark 4+), else `F.expr("try_cast(...)")` (Spark 3.x).
  - Date: `try_to_date()` when available, else `to_date()`.
  - Timestamp: `try_to_timestamp()` when available, else `to_timestamp()`.
- **Tests**: Added tests for try_cast (NULL on invalid) and for columns with spaces in names.
- **Pandas**: Unchanged; only Spark backends are affected.

### Migration

No configuration is required. Pipelines keep getting NULL on invalid casts when moving to Spark v4 / Databricks 14+.
