### PR TITLE
fix: skip cache read in InputNode when cache is disabled

### DIFF
--- a/flypipe/dependency/node_input.py
+++ b/flypipe/dependency/node_input.py
@@ -78,10 +78,21 @@ class InputNode:
                 self.node, root_node, result.get_df()
             )
 
-        elif cache_context and run_status in [
-            RunStatus.CACHED,
-            RunStatus.ACTIVE,  # RunStatus.ACTIVE means it is a Cached node with CacheMode.MERGE
-        ]:
+        elif (
+            cache_context
+            and not cache_context.disabled
+            and run_status
+            in [
+                RunStatus.CACHED,
+                RunStatus.ACTIVE,  # RunStatus.ACTIVE means it is a Cached node with CacheMode.MERGE
+            ]
+        ):
+            # When ``CacheMode.DISABLE`` is set on a node that has a cache, the
+            # runner executes the function body and stores the result in
+            # ``run_context.node_results`` (it does NOT write to cache). The
+            # consumer must therefore use that in-memory result via the ``try``
+            # block below — calling ``cache_context.read()`` would raise
+            # ``RuntimeError("Cache disabled, cannot read")``.
             result = cache_context.read(
                 from_node=self.node, to_node=root_node, is_static=self.static
             )

--- a/flypipe/dependency/node_input_test.py
+++ b/flypipe/dependency/node_input_test.py
@@ -1,15 +1,20 @@
-import pandas as pd
-
-from flypipe import node
-from flypipe.datasource.spark import Spark
-
 from datetime import datetime
+from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 from pandas._testing import assert_frame_equal
 
+from flypipe import node
+from flypipe.cache import CacheMode
+from flypipe.cache.cache import Cache
+from flypipe.cache.cache_context import CacheContext
+from flypipe.datasource.spark import Spark
+from flypipe.dependency.node_input import InputNode
 from flypipe.mode import PreprocessMode
-from flypipe.schema import Schema, Column
+from flypipe.run_context import RunContext
+from flypipe.run_status import RunStatus
+from flypipe.schema import Column, Schema
 from flypipe.schema.types import DateTime, Integer
 
 
@@ -303,6 +308,108 @@ class TestInputNode:
 
         df = n.run()
         assert_frame_equal(df, get_df())
+
+    @pytest.mark.parametrize("run_status", [RunStatus.ACTIVE, RunStatus.CACHED])
+    def test_get_value_uses_in_memory_result_when_cache_disabled(
+        self, mocker, run_status: RunStatus
+    ) -> None:
+        """
+        With CacheMode.DISABLE, the runner stores results in node_results only;
+        InputNode must not call CacheContext.read() (it raises when disabled).
+        """
+
+        class _StubCache(Cache):
+            def read(
+                self,
+                from_node=None,
+                to_node=None,
+                is_static: bool = False,
+            ) -> pd.DataFrame:
+                raise AssertionError("cache read should not be used when disabled")
+
+            def write(self, *args, **kwargs) -> None:
+                pass
+
+            def exists(self, *args, **kwargs) -> bool:
+                return True
+
+        @node(type="pandas", cache=_StubCache())
+        def upstream_dep():
+            return pd.DataFrame({"c1": [0]})
+
+        @node(type="pandas", dependencies=[upstream_dep])
+        def downstream(d):
+            return d
+
+        cache_context = CacheContext(
+            cache_mode=CacheMode.DISABLE,
+            cache=upstream_dep.cache,
+        )
+        read_spy = mocker.spy(cache_context, "read")
+        node_graph = MagicMock()
+        node_graph.get_cache_context.return_value = cache_context
+        node_graph.get_run_status.return_value = run_status
+
+        expected = pd.DataFrame({"c1": [1, 2]})
+        run_context = RunContext()
+        run_context.update_node_results(upstream_dep, downstream, expected)
+
+        input_node = InputNode(upstream_dep)
+        input_node.set_parent_node(downstream)
+        out = input_node.get_value(run_context, node_graph, downstream)
+        assert_frame_equal(out, expected, check_dtype=False)
+        read_spy.assert_not_called()
+
+    def test_run_with_upstream_cache_disabled_does_not_read_node_cache(
+        self, mocker, tmp_path
+    ) -> None:
+        """
+        Integration: full ``run(cache={upstream: DISABLE})`` must not call the
+        upstream node's ``Cache.read`` (in-memory result only).
+        """
+        csv_path = tmp_path / "cache.csv"
+
+        class _PandasFileCache(Cache):
+            def read(
+                self,
+                from_node=None,
+                to_node=None,
+                is_static: bool = False,
+            ) -> pd.DataFrame:
+                return pd.read_csv(csv_path)
+
+            def write(
+                self,
+                *args,
+                df,
+                upstream_nodes=None,
+                to_node=None,
+                datetime_started_transformation=None,
+                **kwargs,
+            ) -> None:
+                df.to_csv(csv_path, index=False)
+
+            def exists(self, *args, **kwargs) -> bool:
+                return csv_path.is_file()
+
+        shared_cache = _PandasFileCache()
+
+        @node(type="pandas", cache=shared_cache)
+        def upstream_node():
+            return pd.DataFrame({"c1": [1, 2]})
+
+        @node(type="pandas", dependencies=[upstream_node])
+        def consumer(upstream_node):
+            return upstream_node
+
+        read_spy = mocker.spy(shared_cache, "read")
+        out = consumer.run(cache={upstream_node: CacheMode.DISABLE})
+        read_spy.assert_not_called()
+        assert_frame_equal(
+            out.reset_index(drop=True),
+            pd.DataFrame({"c1": [1, 2]}),
+            check_dtype=False,
+        )
 
     def test_preprocess_mode_disable_priorities_order(self, monkeypatch):
         monkeypatch.setenv(


### PR DESCRIPTION
When a node is configured with a cache backend but the run uses `CacheMode.DISABLE`, the runner still stores the result in `run_context.node_results` and does not persist to cache. `InputNode.get_value` was still taking the “read from cache” branch whenever the cache context existed and the run status was `CACHED` or `ACTIVE`, which called `CacheContext.read()` and failed with *“Cache disabled, cannot read”*.

**Change:** Only call `cache_context.read()` when the cache context is present **and** not disabled (`not cache_context.disabled`), so consumers always use the in-memory result in that case.

**Test:** Unit test with a disabled `CacheContext` and in-memory `node_results` for both `RunStatus.ACTIVE` and `RunStatus.CACHED`, asserting `read` is not invoked and the returned frame matches.