### PR TITLE
feat!: introduce Node.ref and enforce output/ref boundary at consumers

### DIFF
--- a/docs/notebooks/miscellaneous/build-erd.ipynb
+++ b/docs/notebooks/miscellaneous/build-erd.ipynb
@@ -164,14 +164,14 @@
    "source": [
     "# Build the Relationships\n",
     "\n",
-    "You can define the relationships in the column definition:\n",
+    "You can define the relationships in the column definition. You **must** use `node.ref.<col>` (not `node.output.<col>`) when pointing at a foreign-key target — passing `.output.<col>` raises `ValueError`. The `.ref` accessor preserves the target's `pk` flag for downstream tooling. See the [Relationships](../../relationships.md) doc for details.\n",
     "\n",
     "``` python\n",
     "@node(\n",
     "    ...\n",
     "    output=Schema(\n",
     "        Column(\"node_b_col1\", String(), \"description node_b_col1\", pk=True)\n",
-    "        .many_to_one(A.output.node_a_col1), # <-- relationship\n",
+    "        .many_to_one(A.ref.node_a_col1), # <-- relationship to a PK on A\n",
     "        ...\n",
     "    )\n",
     ")\n",
@@ -221,7 +221,8 @@
     "B.output.node_b_col1.pk = True\n",
     "B.output.node_b_col2.pk = True\n",
     "\n",
-    "B.output.node_b_col1.many_to_one(A.output.node_a_col1)"
+    "# Use A.ref.<col> for the FK target so A.node_a_col1's pk flag is preserved.\n",
+    "B.output.node_b_col1.many_to_one(A.ref.node_a_col1)"
    ]
   },
   {

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -21,10 +21,10 @@ To document the relationships between nodes or tables, you can declare them as f
 @node(
     ...
     output=Schema(
-        Column("col_name", String(), "description)
+        Column("col_name", String(), "description")
 
         # declare the relationship with other nodes output columns
-        .one_to_many(another_node.output.col, "relationship description")
+        .one_to_many(another_node.ref.col, "relationship description")
     )
 def my_node(...):
     ...
@@ -37,6 +37,56 @@ The possible relationships are `.one_to_one(...)`, `.one_to_many(...)`, `.many_t
 !!! warning "Important"
     **Relationships are solely for documentation purposes**; they do not enforce any constraints at runtime.
     Therefore, not documenting relationships has no impact on execution.
+
+## `node.output` vs `node.ref` — which to use where
+
+A `Node` exposes two views over its output schema. Each view is reserved for
+exactly one use case and **flypipe will raise** if you use the wrong one:
+
+* **`node.output`** — for **column-spec inheritance**, i.e. embedding a
+  parent column into a downstream `Schema`:
+
+    ``` py
+    @node(
+        ...
+        output=Schema(
+            parent.output.zip_code,   # reuse name/type/description from parent
+        )
+    )
+    def child(...):
+        ...
+    ```
+
+    The returned column has the parent's `pk` flag and outbound foreign keys
+    stripped, so the child node doesn't accidentally inherit the parent's
+    identity or its FKs.
+
+    Passing `parent.output.<col>` as a relationship target raises `ValueError`.
+
+* **`node.ref`** — for **foreign-key targets**, i.e. when you are pointing
+  *at* a column on another node:
+
+    ``` py
+    @node(
+        ...
+        output=Schema(
+            Column("person_id", String(), "person id")
+                .many_to_one(person.ref.person_id, "person fk"),
+        )
+    )
+    def person_event(...):
+        ...
+    ```
+
+    The returned column has its outbound foreign keys stripped (a relationship
+    target carries no FKs of its own) but its `pk` flag is **preserved**, so
+    downstream tooling (validators, ERD/DBML emitters, lineage tools) can verify
+    that the FK actually points at a primary-key column on the parent.
+
+    Passing `parent.ref.<col>` to `Schema(...)` raises `ValueError`.
+
+Rule of thumb: use `.output` when you are *absorbing* a column, and `.ref`
+when you are *referencing* one.
 
 
 

--- a/flypipe/misc/dbml_test.py
+++ b/flypipe/misc/dbml_test.py
@@ -70,7 +70,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    A.output.node_a_col1
+                    A.ref.node_a_col1
                 )
             ),
         )
@@ -81,7 +81,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_c_col1", String(), "description node_c_col1").one_to_one(
-                    B.output.node_b_col1, "has"
+                    B.ref.node_b_col1, "has"
                 )
             ),
         )
@@ -127,7 +127,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    A.output.node_a_col1
+                    A.ref.node_a_col1
                 )
             ),
         )
@@ -145,7 +145,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_d_col1", String(), "description node_d_col1").one_to_one(
-                    C.output.node_c_col1
+                    C.ref.node_c_col1
                 )
             ),
         )
@@ -213,8 +213,8 @@ class TestDBML:
             ],
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1")
-                .one_to_one(C.output.node_c_col1)
-                .one_to_one(D.output.node_d_col1)
+                .one_to_one(C.ref.node_c_col1)
+                .one_to_one(D.ref.node_d_col1)
             ),
         )
         def B(**dfs):
@@ -274,8 +274,8 @@ class TestDBML:
             ],
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1")
-                .one_to_one(C.output.node_c_col1)
-                .one_to_one(D.output.node_d_col1)
+                .one_to_one(C.ref.node_c_col1)
+                .one_to_one(D.ref.node_d_col1)
             ),
         )
         def B(**dfs):
@@ -327,8 +327,8 @@ class TestDBML:
             ],
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1")
-                .one_to_one(C.output.node_c_col1)
-                .one_to_one(D.output.node_d_col1)
+                .one_to_one(C.ref.node_c_col1)
+                .one_to_one(D.ref.node_d_col1)
             ),
         )
         def B(**dfs):
@@ -389,9 +389,9 @@ class TestDBML:
             ],
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1")
-                .one_to_one(C.output.node_c_col1)
-                .one_to_one(D.output.node_d_col1)
-                .one_to_one(E.output.node_e_col1)
+                .one_to_one(C.ref.node_c_col1)
+                .one_to_one(D.ref.node_d_col1)
+                .one_to_one(E.ref.node_e_col1)
             ),
         )
         def B(**dfs):
@@ -430,7 +430,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    A.output.node_a_col1
+                    A.ref.node_a_col1
                 )
             ),
         )
@@ -475,7 +475,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    C.output.node_c_col1
+                    C.ref.node_c_col1
                 )
             ),
         )
@@ -522,7 +522,7 @@ class TestDBML:
             description="this is node B",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    C.output.node_c_col1, "has"
+                    C.ref.node_c_col1, "has"
                 )
             ),
         )
@@ -565,7 +565,7 @@ class TestDBML:
             type="pandas",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    A.output.node_a_col1
+                    A.ref.node_a_col1
                 )
             ),
         )
@@ -633,7 +633,7 @@ class TestDBML:
             description="this is node B",
             output=Schema(
                 Column("node_b_col1", String(), "description node_b_col1").one_to_one(
-                    C.output.node_c_col1, "has"
+                    C.ref.node_c_col1, "has"
                 )
             ),
         )

--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -100,8 +100,47 @@ class Node(NodeDependenciesMixin):
 
     @property
     def output(self):
+        """Schema view for column-spec inheritance.
+
+        Returns a copy of ``output_schema`` with both outbound relationships
+        and the ``pk`` flag stripped. Use this when embedding a parent
+        column into a downstream ``Schema`` (e.g. ``Schema(parent.output.col)``)
+        so the new node does not accidentally inherit the parent's identity
+        or its foreign keys.
+
+        Columns returned here are stamped with ``_view = "output"`` so that
+        passing one as a relationship target (e.g. ``.many_to_one(...)``) raises
+        — use :pyattr:`ref` for that case so the target's ``pk`` flag is
+        preserved for validation.
+        """
         schema = self.output_schema.copy()
         schema.reset(relationships=True, pk=True)
+        for col in schema.columns:
+            col._view = "output"
+        return schema
+
+    @property
+    def ref(self):
+        """Schema view for foreign-key targets.
+
+        Returns a copy of ``output_schema`` with outbound relationships
+        stripped (a relationship target carries no FKs of its own) but with
+        the ``pk`` flag preserved, so downstream tooling can verify that an
+        FK actually points at a primary-key column on the parent node.
+
+        Intended use::
+
+            Column("person_id", String(), "...")
+                .many_to_one(person.ref.person_id, "person_id FK")
+
+        Columns returned here are stamped with ``_view = "ref"`` so that
+        embedding one in a ``Schema(...)`` raises — use :pyattr:`output` for
+        column-spec inheritance.
+        """
+        schema = self.output_schema.copy()
+        schema.reset(relationships=True, pk=False)
+        for col in schema.columns:
+            col._view = "ref"
         return schema
 
     @property

--- a/flypipe/schema/column.py
+++ b/flypipe/schema/column.py
@@ -66,6 +66,11 @@ class Column:
 
         self.pk = pk
 
+        # Provenance marker set by ``Node.output`` / ``Node.ref`` so consumers can
+        # reject the wrong intent at the call site (see ``Schema.__init__`` and
+        # ``Column._add_relationship``). ``None`` for bare or raw-schema columns.
+        self._view = None
+
     def __repr__(self):
         foreign_key = []
         for dest, relationship in self.relationships.items():
@@ -137,6 +142,16 @@ class Column:
         relationship_type: RelationshipType,
         description: str = None,
     ):
+        if getattr(other, "_view", None) == "output":
+            parent_name = (
+                other.parent.__name__ if other.parent is not None else "<parent>"
+            )
+            raise ValueError(
+                f"Relationship target {parent_name}.{other.name} was passed via "
+                f"`.output`, which strips the parent's `pk` flag. Use `.ref` "
+                f"instead so foreign-key validation can see the target's `pk`:\n"
+                f"    .{relationship_type.name.lower()}({parent_name}.ref.{other.name}, ...)"
+            )
         if self.get_foreign_key(other) is not None:
             raise ValueError(
                 f"Multiple relationships have been set for the same column {self.name}"
@@ -159,7 +174,7 @@ class Column:
             output=Schema(
                 ...
                 Column("col_name", String(), "description)
-                .many_to_one(another_node.output.col, "relationship description")
+                .many_to_one(another_node.ref.col, "relationship description")
                 ...
             )
         )
@@ -184,7 +199,7 @@ class Column:
             output=Schema(
                 ...
                 Column("col_name", String(), "description)
-                .one_to_many(another_node.output.col, "relationship description")
+                .one_to_many(another_node.ref.col, "relationship description")
                 ...
             )
         )
@@ -210,7 +225,7 @@ class Column:
             output=Schema(
                 ...
                 Column("col_name", String(), "description)
-                .many_to_many(another_node.output.col, "relationship description")
+                .many_to_many(another_node.ref.col, "relationship description")
                 ...
             )
         )
@@ -236,7 +251,7 @@ class Column:
             output=Schema(
                 ...
                 Column("col_name", String(), "description)
-                .one_to_one(another_node.output.col, "relationship description")
+                .one_to_one(another_node.ref.col, "relationship description")
                 ...
             )
         )

--- a/flypipe/schema/column_test.py
+++ b/flypipe/schema/column_test.py
@@ -50,9 +50,7 @@ class TestColumn:
             type="pandas",
             output=Schema(
                 [
-                    Column("t2c1", String(), "test").one_to_one(
-                        t1.output.t1c1, "my desc"
-                    ),
+                    Column("t2c1", String(), "test").one_to_one(t1.ref.t1c1, "my desc"),
                 ]
             ),
         )
@@ -83,7 +81,7 @@ class TestColumn:
             output=Schema(
                 [
                     Column("t2c1", String(), "test").many_to_one(
-                        t1.output.t1c1, "my desc"
+                        t1.ref.t1c1, "my desc"
                     ),
                 ]
             ),
@@ -113,7 +111,7 @@ class TestColumn:
             output=Schema(
                 [
                     Column("t2c1", String(), "test").one_to_many(
-                        t1.output.t1c1, "my desc"
+                        t1.ref.t1c1, "my desc"
                     ),
                 ]
             ),
@@ -143,7 +141,7 @@ class TestColumn:
             output=Schema(
                 [
                     Column("t2c1", String(), "test").many_to_many(
-                        t1.output.t1c1, "my desc"
+                        t1.ref.t1c1, "my desc"
                     ),
                 ]
             ),
@@ -212,7 +210,7 @@ class TestColumn:
             type="pyspark",
             output=Schema(
                 Column("node_2_id", String(), "node_2 id").many_to_one(
-                    node_1.output.node_1_id, "as of"
+                    node_1.ref.node_1_id, "as of"
                 )
             ),
         )
@@ -222,7 +220,7 @@ class TestColumn:
         @node(
             type="pyspark",
             output=Schema(
-                node_2.output.node_2_id.many_to_one(node_2.output.node_2_id, "relates")
+                node_2.output.node_2_id.many_to_one(node_2.ref.node_2_id, "relates")
             ),
         )
         def node_3():
@@ -267,7 +265,7 @@ class TestColumn:
             dependencies=[t1.select("t1c1")],
             output=Schema(
                 [
-                    t1.output.t1c1.many_to_one(t1.output.t1c1, "my desc"),
+                    t1.output.t1c1.many_to_one(t1.ref.t1c1, "my desc"),
                 ]
             ),
         )
@@ -293,3 +291,173 @@ class TestColumn:
         assert not t3.output_schema.get("t1c1").relationships
         assert isinstance(t3.output.t1c1.set_pk(True), Column)
         assert t3.output.t1c1.set_pk(True).pk
+
+    def test_ref_preserves_pk_and_resets_relationships(self):
+        """``Node.ref`` is the FK-target accessor: it must preserve the parent
+        column's ``pk`` flag (so FK validators can see it) while still
+        stripping the parent's outbound relationships."""
+
+        @node(
+            type="pandas",
+            output=Schema(
+                [
+                    Column("t1c1", String(), "test", pk=True),
+                ]
+            ),
+        )
+        def t1():
+            pass
+
+        @node(
+            type="pandas",
+            dependencies=[t1.select("t1c1")],
+            output=Schema(
+                [
+                    t1.output.t1c1.many_to_one(t1.ref.t1c1, "self ref"),
+                ]
+            ),
+        )
+        def t2():
+            pass
+
+        ref_col = t1.ref.t1c1
+        assert ref_col.pk is True
+        assert ref_col.relationships == {}
+
+        output_col = t1.output.t1c1
+        assert output_col.pk is False
+
+        ref_col_t2 = t2.ref.t1c1
+        assert ref_col_t2.pk is False
+        assert ref_col_t2.relationships == {}
+
+    def test_ref_returns_independent_copy(self):
+        """Mutations on the value returned by ``Node.ref`` must not leak back
+        into ``output_schema``."""
+
+        @node(
+            type="pandas",
+            output=Schema(
+                [
+                    Column("t1c1", String(), "test", pk=True),
+                ]
+            ),
+        )
+        def t1():
+            pass
+
+        ref_col = t1.ref.t1c1
+        ref_col.set_pk(False)
+
+        assert t1.output_schema.get("t1c1").pk is True
+
+    def test_ref_used_as_fk_target_preserves_pk_in_relationship(self):
+        """When ``parent.ref.<col>`` is passed to ``.many_to_one`` (or any
+        relationship method), the ``Column`` stored as the FK target keeps
+        its ``pk`` flag, which is the whole point of having ``ref``."""
+
+        @node(
+            type="pandas",
+            output=Schema(
+                [
+                    Column("person_id", String(), "person id", pk=True),
+                ]
+            ),
+        )
+        def person():
+            pass
+
+        @node(
+            type="pandas",
+            dependencies=[person.select("person_id")],
+            output=Schema(
+                [
+                    Column("person_id", String(), "fk to person").many_to_one(
+                        person.ref.person_id, "person fk"
+                    ),
+                ]
+            ),
+        )
+        def person_event():
+            pass
+
+        relationships = person_event.output_schema.get("person_id").relationships
+        assert len(relationships) == 1
+        target = next(iter(relationships))
+        assert target.pk is True
+
+    def test_relationship_target_via_output_raises(self):
+        """Passing a column accessed via ``parent.output.<col>`` to a
+        relationship method must raise — that path strips the parent's ``pk``
+        flag and so destroys the validator-facing signal."""
+
+        @node(
+            type="pandas",
+            output=Schema(Column("person_id", String(), "person id", pk=True)),
+        )
+        def person():
+            pass
+
+        with pytest.raises(ValueError) as ex:
+            Column("person_id", String(), "fk to person").many_to_one(
+                person.output.person_id, "person fk"
+            )
+
+        assert "person.person_id" in str(ex.value)
+        assert "`.ref`" in str(ex.value)
+        assert "person.ref.person_id" in str(ex.value)
+
+    def test_schema_with_ref_column_raises(self):
+        """Embedding a ``parent.ref.<col>`` column in ``Schema(...)`` must
+        raise — ``ref`` is reserved for foreign-key targets, so reusing it as
+        a column-spec would silently leak the parent's ``pk`` flag."""
+
+        @node(
+            type="pandas",
+            output=Schema(Column("person_id", String(), "person id", pk=True)),
+        )
+        def person():
+            pass
+
+        with pytest.raises(ValueError) as ex:
+            Schema(person.ref.person_id)
+
+        assert "'person_id'" in str(ex.value)
+        assert "`.output`" in str(ex.value)
+        assert "person.output.person_id" in str(ex.value)
+
+    def test_relationship_target_via_output_schema_does_not_raise(self):
+        """Backwards-compat: passing the raw ``parent.output_schema.<col>``
+        (no marker) as a relationship target must keep working — only the
+        marker-bearing ``.output`` path is rejected."""
+
+        @node(
+            type="pandas",
+            output=Schema(Column("person_id", String(), "person id", pk=True)),
+        )
+        def person():
+            pass
+
+        col = Column("person_id", String(), "fk to person").many_to_one(
+            person.output_schema.person_id, "person fk"
+        )
+
+        relationships = col.relationships
+        assert len(relationships) == 1
+        target = next(iter(relationships))
+        assert target.name == "person_id"
+
+    def test_schema_with_output_column_does_not_raise(self):
+        """Backwards-compat: ``Schema(parent.output.<col>, ...)`` is the
+        canonical column-spec inheritance path and must keep working."""
+
+        @node(
+            type="pandas",
+            output=Schema(Column("person_id", String(), "person id", pk=True)),
+        )
+        def person():
+            pass
+
+        schema = Schema(person.output.person_id)
+        assert schema.get("person_id") is not None
+        assert schema.get("person_id").pk is False

--- a/flypipe/schema/schema.py
+++ b/flypipe/schema/schema.py
@@ -23,6 +23,17 @@ class Schema:
         )
         """
         for col in self.columns:
+            if getattr(col, "_view", None) == "ref":
+                parent_name = (
+                    col.parent.__name__ if col.parent is not None else "<parent>"
+                )
+                raise ValueError(
+                    f"Column {col.name!r} was passed to Schema(...) via "
+                    f"`{parent_name}.ref.{col.name}`, which is reserved for "
+                    f"foreign-key targets (preserves the parent's `pk` flag). "
+                    f"Use `.output` for column-spec inheritance:\n"
+                    f"    Schema({parent_name}.output.{col.name}, ...)"
+                )
             setattr(self, col.name, col)
 
     def reset(self, *, relationships=True, pk=True):

--- a/flypipe/schema/schema_test.py
+++ b/flypipe/schema/schema_test.py
@@ -37,8 +37,8 @@ class TestSchema:
         def f():
             pass
 
-        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.output.col1))
-        schema2 = Schema(Column("col1", String(), "desc").many_to_one(f.output.col1))
+        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.ref.col1))
+        schema2 = Schema(Column("col1", String(), "desc").many_to_one(f.ref.col1))
         assert schema1 == schema2
 
     def test_schema_are_different_with_different_relationships(self):
@@ -46,17 +46,17 @@ class TestSchema:
         def f():
             pass
 
-        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.output.col1))
-        schema2 = Schema(Column("col1", String(), "desc").one_to_many(f.output.col1))
+        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.ref.col1))
+        schema2 = Schema(Column("col1", String(), "desc").one_to_many(f.ref.col1))
         assert schema1 != schema2
 
-        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.output.col1))
+        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.ref.col1))
         schema2 = Schema(
-            Column("col1", String(), "desc").many_to_one(f.output.col1, "has")
+            Column("col1", String(), "desc").many_to_one(f.ref.col1, "has")
         )
         assert schema1 != schema2
 
-        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.output.col1))
+        schema1 = Schema(Column("col1", String(), "desc").many_to_one(f.ref.col1))
         schema2 = Schema(Column("col1", String(), "desc"))
         assert schema1 != schema2
 


### PR DESCRIPTION
Closes #216

> ⚠️ **Breaking change** — title prefixed `feat!:` to trigger a major version bump. See *Migration* below.

## Why?

`Node.output` is overloaded for two semantically different intents:

1. **Column-spec inheritance** — `Schema(parent.output.zip_code, ...)`. The downstream node wants the column's shape but should *not* inherit the parent's PK flag or its outbound FKs. The full reset on `output` (introduced by #204 / #207) is correct here.
2. **Foreign-key declaration** — `.many_to_one(parent.output.person_id, ...)`. Here the downstream node is pointing *at* a column on the parent, and the parent's `pk` flag is exactly the information any FK validator / ERD / lineage tool needs. The current reset destroys it before the relationship is ever stored.

`Node.output` cannot tell which case the caller is in, so today it picks the conservative reset and quietly breaks the FK case. This PR splits the surface into two named accessors and enforces intent at the consumer.

## What changes

### New API

- **`Node.output`** — column-spec inheritance only. Strips relationships and `pk`. Stamps the returned columns with `_view = "output"`.
- **`Node.ref`** — foreign-key targets only. Strips relationships but **preserves `pk`**. Stamps the returned columns with `_view = "ref"`.

### Hard guardrails

| Call site                                  | Behavior                              |
|--------------------------------------------|---------------------------------------|
| `Schema(parent.output.col, ...)`           | ✅ works (column-spec inheritance)    |
| `Schema(parent.ref.col, ...)`              | ❌ raises `ValueError`                |
| `.<rel>(parent.ref.col, ...)`              | ✅ works (FK target with `pk` intact) |
| `.<rel>(parent.output.col, ...)`           | ❌ raises `ValueError`                |
| Bare `Column(...)` / `parent.output_schema.col` | ✅ works (no marker, no rejection) |

The error messages point you at the right accessor:

```
ValueError: Relationship target person.person_id was passed via `.output`,
which strips the parent's `pk` flag. Use `.ref` instead so foreign-key
validation can see the target's `pk`:
    .many_to_one(person.ref.person_id, ...)
```

## Usage

```python
# Column-spec inheritance — full reset (unchanged behavior, now enforced)
Schema(parent.output.zip_code, ...)

# FK target — pk preserved (new accessor, now required for relationships)
Column("person_id", String(), "...")
    .many_to_one(person.ref.person_id, "person fk")
```

## Migration

For every `.many_to_one|one_to_many|many_to_many|one_to_one(<node>.output.<col>, ...)` call site:

```diff
- .many_to_one(person.output.person_id, "person fk")
+ .many_to_one(person.ref.person_id, "person fk")
```

A regex sweep across each consumer repo:

```
\.(many_to_one|one_to_many|many_to_many|one_to_one)\(\s*\n?\s*(\w+)\.output\.
->
.\1(\2.ref.
```

The runtime raise will catch the long tail (variable-aliased targets the regex misses) on first use.

## Test plan

- [x] `test_relationship_target_via_output_raises` — `.many_to_one(person.output.col)` raises with a helpful message pointing at `.ref`.
- [x] `test_schema_with_ref_column_raises` — `Schema(person.ref.col)` raises with a helpful message pointing at `.output`.
- [x] `test_relationship_target_via_output_schema_does_not_raise` — backwards-compat for the raw-schema path.
- [x] `test_schema_with_output_column_does_not_raise` — backwards-compat for canonical column-spec inheritance.
- [x] `test_ref_preserves_pk_and_resets_relationships`, `test_ref_returns_independent_copy`, `test_ref_used_as_fk_target_preserves_pk_in_relationship`.
- [x] All existing schema/column/dbml tests migrated to the new accessor and still passing.
- [x] `make pr-check PYTEST_THREADS=3` — 273 + 301 + 2 unit tests passing in Docker; the only error is a pre-existing `KeyError: 'GITHUB_TOKEN'` in `scripts/generate_changelog.py` (env-only CI tooling).