### PR TITLE
fix: memoize Node.copy and add a visited set to the graph walk to avoid exponential blow-up on diamond dependencies

### DIFF
--- a/flypipe/dependency/node_input.py
+++ b/flypipe/dependency/node_input.py
@@ -197,10 +197,12 @@ class InputNode:
         # periods are not valid argument names so let's replace them with underscores.
         return self.__name__.replace(".", "_").replace("<", "").replace(">", "")
 
-    def copy(self):
+    def copy(self, _memo: dict = None):
         # It's necessary to access protected fields to do a deep copy
         # Note: Don't copy _parent_node to avoid infinite recursion
-        input_node_copy = InputNode(self.node.copy(), self._parent_node)
+        # The wrapper is copied per reference (it carries per-reference state);
+        # only the wrapped node is memoized via ``_memo`` (see Node.copy).
+        input_node_copy = InputNode(self.node.copy(_memo), self._parent_node)
         input_node_copy._selected_columns = self._selected_columns
         input_node_copy._alias = self._alias
         input_node_copy._preprocess = self._preprocess.copy()

--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -410,15 +410,25 @@ class Node(NodeDependenciesMixin):
     def __hash__(self):
         return hash(self.key)
 
-    def copy(self):
-        # Note this is a DEEP copy and will copy all ancestor nodes by extension
+    def copy(self, _memo: dict = None):
+        # Deep copy of this node and all its ancestors, using the same memo
+        # pattern as copy.deepcopy (https://docs.python.org/3/library/copy.html):
+        # ``_memo`` maps id(node) -> copy so each object is copied once per
+        # copying pass, keeping the cost proportional to the DAG size instead of
+        # the number of paths through it. Keyed by id() (not node key) so that
+        # distinct objects sharing a key are still copied separately, preserving
+        # the last-wins semantics of the graph assembly.
+        if _memo is None:
+            _memo = {}
+        if id(self) in _memo:
+            return _memo[id(self)]
         node = Node(
             self.function,
             self.type,
             group=self.group,
             description=self.description,
             tags=list(self.tags),
-            dependencies=[input_node.copy() for input_node in self.input_nodes],
+            dependencies=[input_node.copy(_memo) for input_node in self.input_nodes],
             output=None if self.output_schema is None else self.output_schema.copy(),
             spark_context=self.spark_context,
             requested_columns=self.requested_columns,
@@ -428,6 +438,7 @@ class Node(NodeDependenciesMixin):
         # Accessing protected members in a deep copy method is necessary
         node._key = self._key
         node.node_type = self.node_type
+        _memo[id(self)] = node
         return node
 
 

--- a/flypipe/node_function.py
+++ b/flypipe/node_function.py
@@ -90,17 +90,24 @@ class NodeFunction(Node):
 
         return [node.copy() for node in list(nodes)]
 
-    def copy(self):
+    def copy(self, _memo: dict = None):
+        # Same memo pattern as Node.copy: ``_memo`` (id(node) -> copy) makes
+        # each object be copied once per copying pass.
+        if _memo is None:
+            _memo = {}
+        if id(self) in _memo:
+            return _memo[id(self)]
         node_function = NodeFunction(
             self.function,
             node_dependencies=[
-                dependency.copy() for dependency in self.node_dependencies
+                dependency.copy(_memo) for dependency in self.node_dependencies
             ],
             requested_columns=self.requested_columns,
             output=self.output_schema,
         )
 
         node_function._key = self._key
+        _memo[id(self)] = node_function
         return node_function
 
 

--- a/flypipe/node_graph.py
+++ b/flypipe/node_graph.py
@@ -50,9 +50,19 @@ class NodeGraph:
         graph = nx.DiGraph()
 
         frontier = [transformation]
+        # Standard graph-traversal visited set, by object identity: process
+        # each node object once so the walk costs O(nodes + edges) instead of
+        # one visit per path. Edges are added while processing each dependent,
+        # so skipping an already visited node loses no edges. id() (not key) so
+        # distinct same-key objects keep the last-wins add_node semantics.
+        visited = set()
         while frontier:
 
             current_transformation = frontier.pop()
+
+            if id(current_transformation) in visited:
+                continue
+            visited.add(id(current_transformation))
 
             # We can not add current_transformation.cache now, as current_transformation can be node function
             # so we have to expand node functions and later add cache context to node run context


### PR DESCRIPTION
## Problem

`Node.copy()` deep-copies every ancestor once per reference path, and the `_build_graph` frontier walk revisits each node once per incoming path. In DAGs containing diamonds (the same node reachable through multiple paths), the cost of `create_graph` therefore grows with the number of paths through the graph, which is exponential in the number of stacked diamonds, instead of growing with the number of nodes.

The final graph is small (networkx dedupes by key at insertion), but the intermediate copies are all materialized first, so memory explodes during construction.

Real-world case: on a production task-graph build with 1058 destiny nodes, adding a single new edge (which turned 15 existing nodes into diamond members) made `create_graph` grow past 6 GB of RSS and get OOM-killed. Measured growth was roughly 16x per reference, matching 1 direct path plus 15 paths through the new edge.

## Fix

Two small, mechanical changes, both standard techniques:

1. `Node.copy()` / `NodeFunction.copy()` / `InputNode.copy()` now thread an optional `_memo` dict (id(node) -> copy) through the recursion, so each node object is copied exactly once per copying pass and shared afterwards. This is the same [memo-dictionary pattern used by the standard library's `copy.deepcopy`](https://docs.python.org/3/library/copy.html), which keeps "a memo dictionary of objects already copied during the current copying pass" precisely to avoid re-copying shared components; the `__deepcopy__(self, memo)` protocol likewise passes the memo down to child copies, as done here. Cost becomes proportional to the number of nodes and edges.
2. The `_build_graph` frontier walk now tracks [visited nodes](https://en.wikipedia.org/wiki/Breadth-first_search) (also by id) and skips reprocessing, the standard way to traverse a graph in O(V + E) instead of once per path. Edges into a node are added while processing each of its dependents, so no edges are lost.

Memoization is keyed by object identity rather than node key on purpose (also matching `copy.deepcopy`, whose memo is keyed by `id()`): distinct node objects that happen to share a key (e.g. two `Spark("same_table")` datasource instances) are still copied and processed separately, preserving the existing last-wins `add_node` semantics. This is covered by the existing `test_datasource_consolidate_columns`, which fails with a key-based memo and passes with the id-based one.

`InputNode` wrappers are still copied per reference, since they carry per-reference state (selected columns, alias, static marking, preprocess). Only the wrapped node is memoized.

## Benchmarks

Synthetic, 20 stacked diamonds (61 nodes, about 2^20 simple paths):

| | before | after |
|---|---|---|
| `node.copy()` | explodes (about 1M node copies) | instant, 61 copies |
| `create_graph` | explodes | 1.3 s, correct topology (61 nodes, 80 edges) |

Real production repository (Databricks task-graph codegen that calls `create_graph` over the full pipeline):

| graph | before | after |
|---|---|---|
| 1058-task export graph, with the new diamond edge | OOM-killed (>6 GB RSS) | 6.6 s |
| same graph, without the new edge | 35.4 s / 2.8 GB RSS | 4.2 s |
| 162-task warehouse graph | ok | ok, output unchanged |

## Validation

- Full test suite run on this branch and on unpatched `main` in the same environment: identical results (252 passed and the same pre-existing environment-dependent pandas-on-spark failures in both runs). The patch introduces no new failures.
- `black --check` and `ruff check` clean.
- Output equivalence on the production repository above: the generated task-graph JSONs (1058-task and 162-task) are byte-identical with and without this patch.

No public API change: `copy()` gains an optional parameter that defaults to the previous behavior entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
