### PR TITLE
refact(ci): allow verification on fork PRs

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -46,11 +46,25 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
 
+      # Fork PRs have no origin/$GITHUB_HEAD_REF on the base repo; refs/pull/N/head always points at the PR tip.
+      - name: Resolve git ref for version and changelog
+        id: version_git_ref
+        shell: bash
+        run: |
+          event="${{ github.event_name }}"
+          pr_number="${{ github.event.pull_request.number }}"
+          if { [ "$event" = "pull_request" ] || [ "$event" = "workflow_call" ]; } && [ -n "$pr_number" ]; then
+            git fetch origin "+refs/pull/${pr_number}/head:refs/heads/ci-pr-head"
+            echo "ref=ci-pr-head" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=origin/${{ steps.extract_branch.outputs.branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Package version number (preview)
         run: |
-          python scripts/calculate_version.py origin/${{ steps.extract_branch.outputs.branch }}
+          python scripts/calculate_version.py ${{ steps.version_git_ref.outputs.ref }}
       - name: Changelog (preview)
-        run: python scripts/generate_changelog.py origin/${{ steps.extract_branch.outputs.branch }}
+        run: python scripts/generate_changelog.py ${{ steps.version_git_ref.outputs.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What

- Update **`.github/workflows/verification.yml`** so version/changelog steps don’t rely on `origin/$GITHUB_HEAD_REF` for pull requests.
- Add a step that, for **`pull_request`** (and **`workflow_call`** when `github.event.pull_request.number` is set), runs  
  `git fetch origin +refs/pull/<N>/head:refs/heads/ci-pr-head`  
  and passes **`ci-pr-head`** into `scripts/calculate_version.py` and `scripts/generate_changelog.py`.


## Why

- On the **base** repo runner, **`origin/<head-branch>`** only exists for branches pushed to that remote. **PRs from forks** have their head on the fork, so that ref is missing and **`git rev-list origin/release/…​..origin/<branch>`** fails with “unknown revision”. 
- GitHub always exposes **`refs/pull/<N>/head`** on the base repo for the PR tip (including forks), so fetching it into a local branch gives a stable ref for the same scripts without changing Python code.

