### PR TITLE
fix: exponential graph-build blow-ups on diamond DAGs (Node.copy OOM + per-path traversals)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,12 @@ dmypy.json
 # Pycharm ide files
 .idea
 
+# VSCode ide files
+.vscode/
+
+# macOS files
+.DS_Store
+
 #flypipe files
 /dist/
 /data/

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ ipython_config.py
 # pyenv
 .python-version
 
+# asdf / mise version manager
+.tool-versions
+
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies

--- a/flypipe/dependency/node_input.py
+++ b/flypipe/dependency/node_input.py
@@ -197,10 +197,13 @@ class InputNode:
         # periods are not valid argument names so let's replace them with underscores.
         return self.__name__.replace(".", "_").replace("<", "").replace(">", "")
 
-    def copy(self):
+    def copy(self, _memo: dict = None):
         # It's necessary to access protected fields to do a deep copy
         # Note: Don't copy _parent_node to avoid infinite recursion
-        input_node_copy = InputNode(self.node.copy(), self._parent_node)
+        # The wrapper is copied per reference (it carries per-reference state: alias,
+        # selected_columns, preprocess, static); only the wrapped node is memoized via
+        # _memo, so shared ancestors stay a single shared object after the copy.
+        input_node_copy = InputNode(self.node.copy(_memo), self._parent_node)
         input_node_copy._selected_columns = self._selected_columns
         input_node_copy._alias = self._alias
         input_node_copy._preprocess = self._preprocess.copy()

--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -410,15 +410,24 @@ class Node(NodeDependenciesMixin):
     def __hash__(self):
         return hash(self.key)
 
-    def copy(self):
-        # Note this is a DEEP copy and will copy all ancestor nodes by extension
+    def copy(self, _memo: dict = None):
+        # Note this is a DEEP copy and will copy all ancestor nodes by extension, using the
+        # same memo pattern as copy.deepcopy: ``_memo`` maps id(node) -> copy so each object
+        # is copied once per copying pass, keeping the cost proportional to the DAG size
+        # instead of the number of paths through it. Keyed by id() (not node key) so that
+        # distinct objects sharing a key are still copied separately, preserving last-wins
+        # graph-assembly semantics.
+        if _memo is None:
+            _memo = {}
+        if id(self) in _memo:
+            return _memo[id(self)]
         node = Node(
             self.function,
             self.type,
             group=self.group,
             description=self.description,
             tags=list(self.tags),
-            dependencies=[input_node.copy() for input_node in self.input_nodes],
+            dependencies=[input_node.copy(_memo) for input_node in self.input_nodes],
             output=None if self.output_schema is None else self.output_schema.copy(),
             spark_context=self.spark_context,
             requested_columns=self.requested_columns,
@@ -428,6 +437,7 @@ class Node(NodeDependenciesMixin):
         # Accessing protected members in a deep copy method is necessary
         node._key = self._key
         node.node_type = self.node_type
+        _memo[id(self)] = node
         return node
 
 

--- a/flypipe/node_function.py
+++ b/flypipe/node_function.py
@@ -90,17 +90,24 @@ class NodeFunction(Node):
 
         return [node.copy() for node in list(nodes)]
 
-    def copy(self):
+    def copy(self, _memo: dict = None):
+        # See Node.copy: ``_memo`` maps id(node) -> copy so shared dependencies are
+        # copied once per copying pass instead of once per path through the DAG.
+        if _memo is None:
+            _memo = {}
+        if id(self) in _memo:
+            return _memo[id(self)]
         node_function = NodeFunction(
             self.function,
             node_dependencies=[
-                dependency.copy() for dependency in self.node_dependencies
+                dependency.copy(_memo) for dependency in self.node_dependencies
             ],
             requested_columns=self.requested_columns,
             output=self.output_schema,
         )
 
         node_function._key = self._key
+        _memo[id(self)] = node_function
         return node_function
 
 

--- a/flypipe/node_function_test.py
+++ b/flypipe/node_function_test.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 from flypipe.node import node
-from flypipe.node_function import node_function
+from flypipe.node_function import NodeFunction, node_function
 from flypipe.run_context import RunContext
 from flypipe.schema import Schema, Column
 from flypipe.schema.types import String
@@ -196,6 +196,56 @@ class TestNodeFunction:
 
         end_node = execution_graph.get_node(end_node_name)["transformation"]
         assert t1.output_schema == end_node.output_schema
+
+    def test_copy_memoizes_shared_node_function_dependency(self):
+        """
+        NodeFunction overrides Node.copy, so it must accept and thread the _memo
+        parameter: InputNode.copy passes _memo positionally to self.node.copy
+        whenever a node function sits in the dependency graph. A node function
+        shared by two branches of a diamond must come out of the copy as a single
+        shared object (not one duplicate per path), and its own node_dependencies
+        must go through the same memo so ancestors reachable both through and
+        around the node function stay shared too.
+        """
+
+        @node(type="pandas")
+        def t1():
+            return pd.DataFrame({"c1": [1]})
+
+        @node_function(node_dependencies=[t1])
+        def func():
+            @node(type="pandas", dependencies=[t1])
+            def internal(t1):
+                return t1
+
+            return internal
+
+        @node(type="pandas", dependencies=[func])
+        def left(func):
+            return func
+
+        @node(type="pandas", dependencies=[func])
+        def right(func):
+            return func
+
+        @node(type="pandas", dependencies=[left, right, t1])
+        def tail(left, right, t1):
+            return left
+
+        tail_copy = tail.copy()
+        left_copy, right_copy, t1_input_copy = (
+            input_node.node for input_node in tail_copy.input_nodes
+        )
+
+        func_copy = left_copy.input_nodes[0].node
+        assert isinstance(func_copy, NodeFunction)
+        assert func_copy is not func
+        assert right_copy.input_nodes[0].node is func_copy
+
+        # The node function's dependencies are threaded through the same memo, so
+        # t1 reached through func and t1 reached directly are the same copy
+        assert func_copy.node_dependencies[0] is not t1
+        assert func_copy.node_dependencies[0] is t1_input_copy
 
     def test_node_function_output_is_none_but_return_node_has_output(self):
         col1 = Column("col1", String(), "test")

--- a/flypipe/node_graph.py
+++ b/flypipe/node_graph.py
@@ -50,9 +50,17 @@ class NodeGraph:
         graph = nx.DiGraph()
 
         frontier = [transformation]
+        # Visited tracking is by object identity, mirroring Node.copy's memoization: the
+        # DAG must be walked once per node object, not once per root->node path (which is
+        # exponential on diamond-heavy graphs), while distinct objects sharing a key are
+        # still each processed, preserving last-wins semantics.
+        visited = set()
         while frontier:
 
             current_transformation = frontier.pop()
+            if id(current_transformation) in visited:
+                continue
+            visited.add(id(current_transformation))
 
             # We can not add current_transformation.cache now, as current_transformation can be node function
             # so we have to expand node functions and later add cache context to node run context
@@ -368,6 +376,14 @@ class NodeGraph:
         while len(frontier) != 0:
             current_node_name, descendent_status = frontier.pop()
             current_node = self.graph.nodes[current_node_name]
+
+            # A pop that would re-stamp the status a node already has pushes work
+            # identical to its first processing: skip it. Without this, nodes are
+            # re-processed once per root->node path, which is exponential on
+            # diamond-heavy graphs. Status upgrades (e.g. SKIP -> ACTIVE through a
+            # diamond) still process fully because the stamp differs.
+            if current_node["status"] == descendent_status:
+                continue
 
             if descendent_status == RunStatus.ACTIVE:
                 current_node["status"] = RunStatus.ACTIVE

--- a/flypipe/node_graph_test.py
+++ b/flypipe/node_graph_test.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from flypipe.node import node
+from flypipe.node import Node, node
 from flypipe.node_graph import NodeGraph, RunStatus
 from flypipe.run_context import RunContext
 
@@ -157,3 +157,92 @@ class TestNodeGraph:
             3: [t4.key],
             4: [t5.key],
         }
+
+    def test_build_graph_diamond_chain_copies_linearly(self, monkeypatch):
+        """
+        Building the graph must traverse the DAG once per node — O(nodes) — not once
+        per root->node path, which is O(2**num_diamonds) on a chain of diamonds. That
+        applies to all three traversals: Node.copy (memoized; asserted via the call
+        counter), the _build_graph frontier walk (visited set), and
+        calculate_graph_run_status (duplicate-stamp guard). At 60 diamonds, 2**60
+        paths, any per-path regression hangs this test rather than failing an assert.
+
+            head - left_0 - join_0 - left_1 - join_1 - ...
+                 \\ right_0 /     \\ right_1 /
+        """
+        num_diamonds = 60
+
+        def make_node(name, dependencies):
+            def fn(*dfs):
+                return
+
+            fn.__name__ = name
+            return node(type="pandas", dependencies=dependencies)(fn)
+
+        current = make_node("head", [])
+        for i in range(num_diamonds):
+            left = make_node(f"left_{i}", [current])
+            right = make_node(f"right_{i}", [current])
+            current = make_node(f"join_{i}", [left, right])
+
+        calls = {"count": 0}
+        original_copy = Node.copy
+
+        def counting_copy(self, _memo=None):
+            calls["count"] += 1
+            return original_copy(self, _memo)
+
+        monkeypatch.setattr(Node, "copy", counting_copy)
+        graph = NodeGraph(current, run_context=RunContext())
+
+        # Memoized copy is called once per edge (memo hits included) plus once for the
+        # root: 4 edges per diamond + 1. Unmemoized it is called once per path,
+        # 2**(num_diamonds + 2) - 3 times.
+        assert calls["count"] <= 4 * num_diamonds + 1
+
+        # The duplicate-stamp guard in calculate_graph_run_status must not swallow
+        # any first-time stamp: with no caches or provided inputs, every node is ACTIVE.
+        for node_key in graph.graph.nodes:
+            assert graph.get_node(node_key)["status"] == RunStatus.ACTIVE
+
+    def test_calculate_graph_run_status_skip_upgraded_to_active_through_diamond(self):
+        """
+        A node first reached through a non-executing branch (provided input, so its
+        ancestors are pushed as SKIP) and later reached through an executing branch
+        must end up ACTIVE. The duplicate-stamp guard in calculate_graph_run_status
+        only drops pops that re-apply the status a node already has; this locks in
+        that pops which *change* a status (SKIP -> ACTIVE here) still process fully.
+
+            t1 - active_branch   - tail
+               \\ provided_branch /
+        """
+
+        @node(type="pandas")
+        def t1():
+            return
+
+        @node(type="pandas", dependencies=[t1.select("c1")])
+        def active_branch(t1):
+            return
+
+        @node(type="pandas", dependencies=[t1.select("c1")])
+        def provided_branch(t1):
+            return
+
+        @node(
+            type="pandas",
+            dependencies=[active_branch.select("c1"), provided_branch.select("c1")],
+        )
+        def tail(active_branch, provided_branch):
+            return
+
+        graph = NodeGraph(
+            tail,
+            run_context=RunContext(provided_inputs={provided_branch: pd.DataFrame()}),
+        )
+
+        assert graph.get_node(tail.key)["status"] == RunStatus.ACTIVE
+        assert graph.get_node(provided_branch.key)["status"] == RunStatus.PROVIDED_INPUT
+        assert graph.get_node(active_branch.key)["status"] == RunStatus.ACTIVE
+        # t1 must run for the active branch even though the provided branch skips it
+        assert graph.get_node(t1.key)["status"] == RunStatus.ACTIVE

--- a/flypipe/node_test.py
+++ b/flypipe/node_test.py
@@ -1034,3 +1034,48 @@ class TestNode:
         @node(type="pandas", cache=MyCache())
         def t1():
             return pd.DataFrame(data={"col1": [1]})
+
+    def test_copy_preserves_shared_ancestor_identity(self):
+        """
+        Node.copy memoizes per copying pass: an ancestor shared by two branches of a
+        diamond must come out of the copy as a single shared object (not one duplicate
+        per path), while the InputNode wrappers stay distinct, keeping their per-edge
+        state (selected columns). Separate copy passes remain fully independent.
+        """
+
+        @node(type="pandas")
+        def head():
+            return pd.DataFrame(data={"c1": [1], "c2": [2]})
+
+        @node(type="pandas", dependencies=[head.select("c1")])
+        def left(head):
+            return head
+
+        @node(type="pandas", dependencies=[head.select("c2")])
+        def right(head):
+            return head
+
+        @node(type="pandas", dependencies=[left.select("c1"), right.select("c2")])
+        def tail(left, right):
+            return left
+
+        tail_copy = tail.copy()
+        left_copy, right_copy = (
+            input_node.node for input_node in tail_copy.input_nodes
+        )
+
+        # The wrappers are per-edge: distinct objects, per-edge state preserved
+        assert left_copy.input_nodes[0] is not right_copy.input_nodes[0]
+        assert left_copy.input_nodes[0].selected_columns == ["c1"]
+        assert right_copy.input_nodes[0].selected_columns == ["c2"]
+
+        # The shared ancestor is copied exactly once and shared between branches
+        assert left_copy.input_nodes[0].node is right_copy.input_nodes[0].node
+        assert left_copy.input_nodes[0].node is not head
+
+        # A second copy pass is fully independent from the first
+        tail_copy2 = tail.copy()
+        assert (
+            tail_copy2.input_nodes[0].node.input_nodes[0].node
+            is not left_copy.input_nodes[0].node
+        )


### PR DESCRIPTION
Closes #222

## TL;DR — one disease, three locations

Building a `NodeGraph` traversed the dependency DAG **once per root→node path** instead of **once per node**, in three independent places. On diamond-heavy DAGs the path count is exponential in diamond depth, so each one blows up — they just hid behind each other in execution order (fixing #1 unmasked #2, fixing #2 unmasked #3):

| # | Where | Resource burned | Symptom |
|---|---|---|---|
| 1 | `Node.copy()` (`flypipe/node.py`) | memory | **OOM at ~7.5 GB** (the original report: datahub export graph, 1,803 nodes, >1M copies) |
| 2 | `_build_graph()` frontier walk (`flypipe/node_graph.py`) | CPU (heavy per visit) | minutes→forever at 99% CPU, flat RSS |
| 3 | `calculate_graph_run_status()` (`flypipe/node_graph.py`) | CPU (cheap per visit) | seconds→hours, flat RSS |

All three fixes share one idea: track what's already been handled so cost is proportional to the DAG **size**, not its **path count**.

## The fixes

**1. `Node.copy()` — memoize the deep copy (the OOM).** The unmemoized copy unfolds the DAG into a *tree*: every shared ancestor is re-copied once per path, and all ~2^N copies are simultaneously reachable from the root copy. The fix threads a `_memo` dict through the recursion, `copy.deepcopy`-style:

- Keyed by **`id(self)`, not node key** — distinct objects can legitimately share a key during graph assembly (last-wins), and `Node.__eq__`/`__hash__` are key-based, so `id()` also sidesteps accidental dict collisions.
- `InputNode.copy` **threads the memo but is never memoized itself**: an `InputNode` is an *edge* carrying per-reference state (alias, selected columns, preprocess, static). Two edges into the same node stay two distinct wrappers around one shared copied node.
- `NodeFunction.copy` overrides `Node.copy`, so it must accept and thread `_memo` (it's dispatched to whenever a node function sits in a dependency graph) and memoizes itself the same way.

**2. `_build_graph()` — visited set on the frontier walk.** The BFS popped a node and unconditionally re-queued all its dependencies — once per path. Identity-keyed `visited` set, mirroring the memo: each node object processed once, every edge still added.

**3. `calculate_graph_run_status()` — duplicate-stamp guard.** The status walk pushed `(node, status)` pairs upward; the ACTIVE branch re-stamped and re-pushed predecessors unconditionally (and the SKIP guard didn't exclude SKIP-stamped nodes), so nodes were re-processed once per path. The fix drops any pop that would re-apply the status a node already has — its first identical processing already pushed the same work. Status **changes** (e.g. the SKIP → ACTIVE upgrade when a node first reached through a cached/provided branch is later reached through an executing branch) still process fully because the stamp differs.

## Measured impact

Reproducer: a chain of N diamonds — node count `3N+1`, path count `2^N` (same shape as the datahub graph). Per-stage baselines: at N=22 stock flypipe OOM-killed a 7.5 GB box after >11M copies; with only fix #1, the build burned 8+ CPU-minutes in the frontier walk; with #1+#2, `calculate_graph_run_status` took 5.2 s at N=20 (profiled: 4,194,301 `predecessors` calls = 2^22−3). With all three:

| N | nodes | paths | copy calls | node visits | RSS | build time |
|---|---|---|---|---|---|---|
| 12 | 37 | 4,096 | 49 | 37 | flat | 0.000 s |
| 22 | 67 | 4,194,304 (OOM'd before) | 89 | 67 | flat | **0.001 s** |
| 30 | 91 | 1.07×10⁹ | 121 | 91 | flat | 0.001 s |
| 100 | 301 | 1.27×10³⁰ | 401 | 301 | flat | **0.003 s** |

Copy calls = one per edge + root (memo hits included); visits = exactly the node count.

## Tests

- `test_build_graph_diamond_chain_copies_linearly` — 60-diamond chain (2^60 paths): asserts O(nodes) copy calls and that every node is stamped ACTIVE. Any future per-path regression doesn't fail an assert — it hangs the test at 2^60 operations, which CI can't miss.
- `test_copy_preserves_shared_ancestor_identity` — after a copy, a shared ancestor is a *single shared object* while the `InputNode` wrappers stay distinct with their per-edge state; separate copy passes stay independent.
- `test_copy_memoizes_shared_node_function_dependency` — a `NodeFunction` shared by two branches copies once, and its `node_dependencies` go through the same memo (a node reachable both through and around the node function stays one object).
- `test_calculate_graph_run_status_skip_upgraded_to_active_through_diamond` — pins the upgrade semantics of the status guard. Mutation-verified: swapping the guard for a naive "visited node → skip" implementation makes this test fail.

Every changed executable statement is covered (verified with `pytest --cov`, per-test attribution: both branches of every new guard — fire and pass-through — are exercised by at least one dedicated test). Full suite: 277 passed; the 2 `utils_test.py` failures occur identically on a clean tree (pre-existing order-dependent flakes, unrelated).

## Behavior notes

- The only observable change: ancestors that were a single shared object before a copy remain a single shared object after it (previously they became per-path duplicates that graph assembly collapsed by key anyway).
- Pre-existing quirk noticed but deliberately untouched (guard behavior is bit-identical for all status-*changing* pops): the SKIP branch of `calculate_graph_run_status` stamps unconditionally, so in a rare pop-order interleaving an ACTIVE-stamped node could be downgraded to SKIP. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
