### PR TITLE
#224 Free node results mid-run once all consumers have read them

### DIFF
--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -306,7 +306,10 @@ class Node(NodeDependenciesMixin):
           nodes level-by-level based on dependencies.
         - Cached nodes with CacheMode.MERGE trigger CDC filtering for upstream dependencies,
           processing only changed data.
-        - All intermediate results are stored in run_context.node_results for memoization.
+        - Intermediate results are stored in run_context.node_results and freed as soon
+          as all downstream consumers have run, keeping only the in-flight working set
+          in memory. This also applies inside the recursive sub-runs that
+          CacheMode.MERGE nodes trigger (each run tracks its consumers independently).
         - The method is thread-safe for parallel execution when max_workers > 1.
         """
         inputs = inputs or {}

--- a/flypipe/run_context.py
+++ b/flypipe/run_context.py
@@ -105,7 +105,16 @@ class RunContext:
         PandasApiDataFrame,
         PySparkConnectDataFrame,
     ]:
-        return self.node_results[node][node].as_type(node.dataframe_type).get_df()
+        """Return the run's final dataframe and release its stored NodeResult.
+
+        This is the last read of the run (called once, as ``Node.run`` returns),
+        so after it node_results holds no results at all -- only the returned
+        dataframe stays alive, not the NodeResult wrapper (which may also hold
+        a pre-conversion copy in the node's storage type).
+        """
+        result = self.node_results[node][node].as_type(node.dataframe_type).get_df()
+        self.release_node_result(node, node)
+        return result
 
     def update_node_results(
         self,
@@ -121,6 +130,23 @@ class RunContext:
         self.node_results[from_node][to_node] = NodeResult(
             self.spark, df, schema=from_node.output_schema
         )
+
+    def release_node_result(self, from_node: "Node", to_node: "Node"):
+        """Drop a stored node result so its dataframe can be garbage-collected
+        mid-run, once every downstream consumer has read it.
+
+        Uses ``dict.get``/``pop`` rather than item access so the ``Autodict``
+        does not auto-create empty entries for already-released nodes. The
+        outer ``node_results[from_node]`` entry is deliberately left in place
+        even when emptied: a concurrent CacheMode.MERGE sub-run may be
+        re-populating it under its own target key (``Autodict`` does a
+        get-then-set, so deleting the inner dict between those two steps would
+        silently drop the sub-run's write).
+        """
+        consumers = self.node_results.get(from_node)
+        if consumers is None:
+            return
+        consumers.pop(to_node, None)
 
     def has_provided_input(self, node: "Node") -> bool:
         """

--- a/flypipe/run_context_test.py
+++ b/flypipe/run_context_test.py
@@ -1,7 +1,19 @@
 import pandas as pd
+from flypipe.cache import CacheMode
+from flypipe.cache.cache import Cache
 from flypipe.dependency.preprocess_mode import PreprocessMode
 from flypipe.node import node
 from flypipe.run_context import RunContext
+from flypipe.runner import Runner
+
+
+def _run_with_inspectable_context(target, run_context):
+    """Execute ``target`` exactly the way Node.run does internally, but with a
+    caller-supplied RunContext so tests can inspect it after the run."""
+    target.create_graph(run_context)
+    execution_graph = target.node_graph.get_execution_graph(run_context)
+    Runner(node_graph=execution_graph, run_context=run_context).run(target_node=target)
+    return run_context.get_graph_result(target)
 
 
 @node(type="pandas")
@@ -12,6 +24,55 @@ def t1():
 @node(type="pandas", dependencies=[t1])
 def t2(t1):
     return t1
+
+
+class InMemoryCache(Cache):
+    """Minimal cache for exercising cached/MERGE flows without touching disk."""
+
+    def __init__(self):
+        self.df = None
+
+    def read(self, from_node=None, to_node=None, is_static=False):
+        return self.df
+
+    def write(
+        self,
+        df,
+        upstream_nodes=None,
+        to_node=None,
+        datetime_started_transformation=None,
+    ):
+        self.df = df
+
+    def exists(self):
+        return self.df is not None
+
+
+def _make_identity_transform(i):
+    """Build a uniquely-named identity transform (distinct __name__ -> distinct
+    node key) for assembling a serial chain in tests."""
+
+    def transform(df):
+        return df
+
+    transform.__name__ = f"chain_{i}"
+    return transform
+
+
+def _build_identity_chain(num_nodes):
+    """chain_0 -> chain_1 -> ... -> chain_{num_nodes-1}; returns the tail node."""
+
+    @node(type="pandas")
+    def chain_0():
+        return pd.DataFrame({"x": [1, 2, 3]})
+
+    chain_0.name = "chain_0"
+    nodes = [chain_0]
+    for i in range(1, num_nodes):
+        prev = nodes[-1]
+        transform = _make_identity_transform(i)
+        nodes.append(node(type="pandas", dependencies=[prev.alias("df")])(transform))
+    return nodes[-1]
 
 
 class TestRunContext:
@@ -39,3 +100,164 @@ class TestRunContext:
         assert (
             run_context.get_dependency_preprocess_mode(t2, t1) == PreprocessMode.DISABLE
         )
+
+    def test_release_node_result_removes_entry(self):
+        run_context = RunContext()
+        run_context.update_node_results(t1, t2, pd.DataFrame({"x": [1]}))
+        assert t1 in run_context.node_results
+        assert t2 in run_context.node_results[t1]
+
+        run_context.release_node_result(t1, t2)
+
+        # The inner entry is dropped; the outer key stays (a concurrent MERGE
+        # sub-run may be re-populating it under its own target key).
+        assert t2 not in run_context.node_results[t1]
+
+    def test_release_node_result_missing_is_noop(self):
+        run_context = RunContext()
+        # Must not raise and must not auto-create an Autodict entry.
+        run_context.release_node_result(t1, t2)
+        assert t1 not in run_context.node_results
+
+
+class TestReleaseIntermediate:
+    """Tests for the mid-run eviction of intermediate node results."""
+
+    def test_returns_correct_result(self):
+        result = _build_identity_chain(6).run()
+
+        assert result["x"].tolist() == [1, 2, 3]
+
+    def test_frees_intermediate_results_during_run(self):
+        tail = _build_identity_chain(6)
+
+        # Measure (do NOT evict) the peak number of stored results by observing
+        # node_results after each store. The library does the eviction.
+        peak = {"max": 0}
+        original = RunContext.update_node_results
+
+        def measured(self, from_node, to_node, df):
+            original(self, from_node, to_node, df)
+            held = sum(len(inner) for inner in self.node_results.values())
+            peak["max"] = max(peak["max"], held)
+
+        RunContext.update_node_results = measured
+        try:
+            result = tail.run()
+        finally:
+            RunContext.update_node_results = original
+
+        # Only the in-flight working set (current input + current output) is ever
+        # held, regardless of chain length.
+        assert peak["max"] <= 2
+        assert result["x"].tolist() == [1, 2, 3]
+
+    def test_evicts_through_merge_cache_recursion(self):
+        """A CacheMode.MERGE node mid-graph re-enters Runner.run with itself as
+        target; eviction must work independently in both the outer and the
+        inner run, and the inner run's own result (only needed to write the
+        merged cache) must be freed when it ends."""
+
+        @node(type="pandas")
+        def source():
+            return pd.DataFrame({"x": [1, 2, 3]})
+
+        @node(type="pandas", dependencies=[source.alias("df")], cache=InMemoryCache())
+        def cached_mid(df):
+            return df
+
+        @node(type="pandas", dependencies=[cached_mid.alias("df")])
+        def downstream(df):
+            return df
+
+        @node(type="pandas", dependencies=[downstream.alias("df")])
+        def tail(df):
+            return df
+
+        run_context = RunContext(cache_modes={cached_mid: CacheMode.MERGE})
+
+        # Track the peak number of simultaneously stored results; this needs a
+        # hook (mid-run state cannot be reconstructed after the run), hence the
+        # try/finally to guarantee the class-level patch is undone.
+        peak = {"max": 0}
+        original = RunContext.update_node_results
+
+        def measured(self, from_node, to_node, df):
+            original(self, from_node, to_node, df)
+            held = sum(len(inner) for inner in self.node_results.values())
+            peak["max"] = max(peak["max"], held)
+
+        RunContext.update_node_results = measured
+        try:
+            result = _run_with_inspectable_context(tail, run_context)
+        finally:
+            RunContext.update_node_results = original
+
+        assert result["x"].tolist() == [1, 2, 3]
+        # 6 results get stored across the outer + inner run (source twice, the
+        # merge node twice, downstream, tail); eviction keeps at most 3 alive.
+        assert peak["max"] <= 3
+        # After the run nothing survives -- even the target's result is
+        # released by get_graph_result when it is handed back to the caller.
+        held_at_end = sum(len(inner) for inner in run_context.node_results.values())
+        assert held_at_end == 0
+
+    def test_merge_run_holds_no_dataframes_after_run(self):
+        """A -> B (cached) -> C, run from C with B merged: once run() returns,
+        run_context must hold no dataframes at all -- every intermediate is
+        evicted mid-run and the target's own result is released by
+        get_graph_result when it is handed back to the caller."""
+
+        @node(type="pandas")
+        def A():
+            return pd.DataFrame({"x": [1, 2, 3]})
+
+        @node(type="pandas", dependencies=[A.alias("df")], cache=InMemoryCache())
+        def B(df):
+            return df
+
+        @node(type="pandas", dependencies=[B.alias("df")])
+        def C(df):
+            return df
+
+        run_context = RunContext(cache_modes={B: CacheMode.MERGE})
+        result = _run_with_inspectable_context(C, run_context)
+
+        assert result["x"].tolist() == [1, 2, 3]
+        held_at_end = sum(len(inner) for inner in run_context.node_results.values())
+        assert held_at_end == 0
+
+    def test_evicts_through_merge_cache_recursion_parallel(self):
+        """With max_workers > 1 a MERGE sub-run executes inside a worker thread,
+        concurrently with the rest of its level and with the outer run's
+        releases; results and eviction must stay correct."""
+
+        @node(type="pandas")
+        def source():
+            return pd.DataFrame({"x": [1, 2, 3]})
+
+        @node(type="pandas", dependencies=[source.alias("df")])
+        def left(df):
+            return df
+
+        @node(type="pandas", dependencies=[source.alias("df")], cache=InMemoryCache())
+        def cached_mid(df):
+            return df
+
+        @node(
+            type="pandas",
+            dependencies=[left.alias("a"), cached_mid.alias("b")],
+        )
+        def tail(a, b):
+            return a + b
+
+        run_context = RunContext(
+            max_workers=2, cache_modes={cached_mid: CacheMode.MERGE}
+        )
+        result = _run_with_inspectable_context(tail, run_context)
+
+        assert result["x"].tolist() == [2, 4, 6]
+        # After the run nothing survives -- even the target's result is
+        # released by get_graph_result when it is handed back to the caller.
+        held_at_end = sum(len(inner) for inner in run_context.node_results.values())
+        assert held_at_end == 0

--- a/flypipe/runner.py
+++ b/flypipe/runner.py
@@ -427,6 +427,11 @@ class Runner:
                     logger.debug(
                         f"{'*'*26} Finished Node '{node_name}' MERGE mode {'*'*26}\n"
                     )
+                    # The sub-run above has computed this node and written its
+                    # merged result to the cache. We therefore skip storing a
+                    # result here: this node's successors will load it by
+                    # reading the cache in get_node_inputs (InputNode.get_value),
+                    # not from run_context.node_results.
                     return
 
             # Normal ACTIVE node - get dependencies and execute

--- a/flypipe/runner.py
+++ b/flypipe/runner.py
@@ -38,6 +38,46 @@ class Runner:
         self.node_graph = node_graph
         self.run_context = run_context
 
+        # _pending_consumers drives a mid-run memory optimisation. For each
+        # in-flight run() invocation (keyed by its target node, since
+        # CacheMode.MERGE re-enters run() with the merge node as a new target)
+        # it maps each node of that run's execution plan to the number of its
+        # direct downstream consumers that have not run yet. Whenever a node
+        # finishes, _release_consumed_parents decrements the counter of each of
+        # its parents; a counter reaching zero means no future node of that run
+        # will ever read the parent's result (results are stored and read keyed
+        # by the run's target, so concurrent runs never share entries), so its
+        # dataframe is freed from run_context.node_results immediately instead
+        # of being held until the run ends. The target node is exempt (its
+        # result is the run's return value).
+        self._pending_consumers = {}
+
+    def _release_consumed_parents(self, node: "Node", target_node: "Node"):
+        """Free the stored results of ``node``'s parents whose every consumer
+        of run(``target_node``) has now run.
+
+        A node reads all of its parents before it returns, so this is called
+        right after a node completes. Because a parent is only released once
+        its LAST consumer has fully finished, no consumer can still be reading
+        it -- and a run's counters are only ever mutated by the single thread
+        executing that run's level loop (a MERGE sub-run has its own target,
+        hence its own counters), so no locking is required even when
+        ``max_workers > 1``.
+        """
+        pending = self._pending_consumers.get(target_node.key)
+        if pending is None:
+            return
+        for parent_key in self.node_graph.graph.predecessors(node.key):
+            if parent_key not in pending:
+                continue  # parent is not part of this run's execution plan
+            pending[parent_key] -= 1
+            if pending[parent_key] > 0:
+                continue  # at least one consumer of this parent hasn't run yet
+            parent = self.node_graph.get_transformation(parent_key)
+            if parent == target_node:
+                continue  # never free the run's return value
+            self.run_context.release_node_result(parent, target_node)
+
     def create_execution_plan(self, target_node: "Node") -> List[List[str]]:
         """
         Create a logical execution plan with levels.
@@ -161,12 +201,32 @@ class Runner:
         # Create execution plan
         execution_plan = self.create_execution_plan(target_node)
 
+        # Count, per node, how many consumers will read it within THIS run's
+        # plan (edges to nodes outside the plan never run, so they must not be
+        # counted or the counters would never reach zero).
+        plan_nodes = {node_key for level in execution_plan for node_key in level}
+        self._pending_consumers[target_node.key] = {
+            node_key: sum(
+                1
+                for successor in self.node_graph.graph.successors(node_key)
+                if successor in plan_nodes
+            )
+            for node_key in plan_nodes
+        }
+
         # Execute level by level
         for level_idx, level in enumerate(execution_plan):
             logger.debug(f"\n🛠️ Executing Level {level_idx} ({len(level)} nodes)")
             logger.debug(f"{'-'*60}")
 
             self._execute_level(level, target_node, process_merge, max_workers)
+
+        if not process_merge:
+            # This is a CacheMode.MERGE sub-run: its target's result was only
+            # needed to write the merged cache, which has happened by now --
+            # consumers in the parent run re-read it from the cache.
+            self.run_context.release_node_result(target_node, target_node)
+        self._pending_consumers.pop(target_node.key, None)
 
         logger.debug("\n✅  Runner: Execution completed 👍")
         logger.debug(f"{'='*60}")
@@ -215,6 +275,7 @@ class Runner:
                 node = self.node_graph.get_transformation(node_key)
                 logger.debug(f"    ▶️ Executing {node.__name__}")
                 self._process_single_node(node, target_node, process_merge)
+                self._release_consumed_parents(node, target_node)
         else:
             # Multiple nodes, execute in parallel
             logger.debug(
@@ -240,10 +301,12 @@ class Runner:
                 # Wait for all nodes to complete
                 for future in as_completed(future_to_node):
                     node_key = future_to_node[future]
-                    node_name = self.node_graph.get_transformation(node_key).__name__
+                    node = self.node_graph.get_transformation(node_key)
+                    node_name = node.__name__
                     try:
                         future.result()
                         logger.debug(f"    ✅ {node_name} completed successfully")
+                        self._release_consumed_parents(node, target_node)
                     except Exception as e:
                         logger.debug(f"    ❌ {node_name} failed with error: {e}")
                         raise


### PR DESCRIPTION
## Problem

During `Node.run()`, every node's output dataframe is stored in `run_context.node_results` and **retained until the entire run finishes** — even after all of its downstream consumers have already read it. Peak memory therefore grows with the *total number of nodes*, not the in-flight working set, which can OOM runs whose individual steps would otherwise fit comfortably in memory.

Closes #224.

## Change

The `Runner` now reference-counts the DAG and frees each node's stored result the moment its last consumer has run:

- Each node starts with a **pending-consumer count == its out-degree within the run's execution plan** (edges to nodes that won't execute in this run aren't counted).
- When a node finishes, the counter of each of its parents is decremented; a counter hitting zero means no future node will read that parent's result, so it's released from `run_context.node_results` immediately.
- Counters are keyed **per run target**, so a `CacheMode.MERGE` node's recursive sub-run (which re-enters `run()` with itself as a new target) tracks its consumers independently of the outer run. **Full cache support — no auto-disable.**
- `get_graph_result` releases the target's own result as it hands the dataframe back, so a **finished run holds zero results**.

A serial chain of N nodes now holds at most 2 results at a time instead of N.

### Thread-safety note

`release_node_result` deliberately does **not** delete the emptied outer `node_results[from_node]` key. With `max_workers > 1` a MERGE sub-run runs in a worker thread and may be re-populating that key under its own target via `Autodict`'s get-then-set; deleting the inner dict between those two steps would silently drop the sub-run's write. The per-target counters are single-writer (the thread executing that run's level loop), so no locking is needed.

## Graph flow

Take `A -> B -> C`, where **B is cached**, run from `C` with `B` in `CacheMode.MERGE`. Because B is a MERGE node, the runner re-enters `run()` mid-flight with B as a new target (its own execution plan + its own consumer counters).

### Before this PR

All five stored results accumulate and are held until the run ends:

```
store [A][C]    held: 1
store [A][B]    held: 2     # B's MERGE sub-run re-computes A
store [B][B]    held: 3
store [B][C]    held: 4     # C reads B from the cache
store [C][C]    held: 5
                            # run ends -> 5 still in run_context (peak == total stores)
```

**Dataframes left in run_context after the run: up to 5** (everything; only freed when the RunContext is garbage-collected).

### After this PR

```
 #   Event             Held   What's happening
 1   store   [A][C]      1    Outer run (target C): A executes
 2   store   [A][B]      2    B is MERGE -> sub-run starts with B as target, re-computes A
 3   store   [B][B]      3    Sub-run executes B, writes the merged cache    <- peak
 4   release [A][B]      2    B was A's last consumer in the sub-run
 5   release [B][B]      1    Sub-run ends; its result existed only to write the cache
 6   release [A][C]      0    Back in the outer run: B completed, A's last outer consumer
 7   store   [B][C]      1    C loads input B by reading the cache, stored under target C
 8   store   [C][C]      2    C executes — the run's final result
 9   release [B][C]      1    C finished; B's cached copy no longer needed
10   release [C][C]      0    get_graph_result extracts the return df, releases the wrapper
```

**Peak held: 3. Dataframes left in run_context after the run: 0.** The only surviving object is the dataframe returned to the caller.

## Tests

`flypipe/run_context_test.py`:

- `test_frees_intermediate_results_during_run` — a 6-node serial chain holds at most 2 results at any time.
- `test_evicts_through_merge_cache_recursion` — eviction works independently across the outer run and a MERGE sub-run; peak ≤ 3, zero held at the end.
- `test_merge_run_holds_no_dataframes_after_run` — the `A -> B(cached) -> C` graph above: `run_context` holds **zero** dataframes once `run()` returns.
- `test_evicts_through_merge_cache_recursion_parallel` — same with `max_workers=2`, exercising the worker-thread re-entrancy.

Full suite green locally except two pre-existing order-dependent `utils_test` flakes unrelated to this change. The Spark Connect CDC/MERGE suites run in CI (`USE_SPARK_CONNECT=0` and `=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
