### PR TITLE
#226 Copy node DAGs iteratively to remove the recursion-depth ceiling

### DIFF
--- a/flypipe/node.py
+++ b/flypipe/node.py
@@ -424,6 +424,59 @@ class Node(NodeDependenciesMixin):
             _memo = {}
         if id(self) in _memo:
             return _memo[id(self)]
+        # Ancestors are copied iteratively, predecessors before the nodes that
+        # consume them (an explicit post-order traversal), rather than by
+        # recursive descent: recursion costs ~3 stack frames per ancestor level
+        # (copy -> InputNode.copy -> copy), so a chain a few hundred nodes deep
+        # would overflow Python's recursion limit. Once every predecessor of a
+        # node is in _memo, _copy_node builds its copy without descending
+        # further.
+        stack = [self]
+        expanding = set()  # ids of nodes whose predecessors are still being copied
+        while stack:
+            current = stack[-1]
+            if id(current) in _memo:
+                stack.pop()
+                expanding.discard(id(current))
+                continue
+            pending = [
+                predecessor
+                for predecessor in current._predecessor_nodes()
+                if id(predecessor) not in _memo
+            ]
+            if pending:
+                # In a DAG a node only resurfaces once everything it pushed has
+                # been copied, so pending predecessors on a second surfacing
+                # mean this node is its own ancestor (a cycle). The recursive
+                # code failed fast on this (RecursionError); without the check
+                # the loop would hang.
+                if id(current) in expanding:
+                    raise ValueError(
+                        f"Dependency cycle detected while copying node {current.__name__}"
+                    )
+                expanding.add(id(current))
+                # reversed so the LIFO stack copies sibling predecessors left
+                # to right (input_nodes order), matching the recursive code's
+                # construction-time side-effect order (e.g. validation errors
+                # surface for the same node).
+                stack.extend(reversed(pending))
+                continue
+            stack.pop()
+            expanding.discard(id(current))
+            _memo[id(current)] = current._copy_node(_memo)
+        return _memo[id(self)]
+
+    def _predecessor_nodes(self):
+        # This node's direct predecessors (the upstream nodes it consumes),
+        # unwrapped from their per-edge InputNode wrappers. NodeFunction
+        # overrides this (its predecessors are bare nodes), letting copy()
+        # traverse mixed graphs polymorphically.
+        return [input_node.node for input_node in self.input_nodes]
+
+    def _copy_node(self, _memo: dict):
+        # Copies this single node. Every ancestor is already in _memo (guaranteed
+        # by the predecessors-first traversal in copy()), so the InputNode.copy
+        # calls below resolve from the memo without recursing.
         node = Node(
             self.function,
             self.type,
@@ -440,7 +493,6 @@ class Node(NodeDependenciesMixin):
         # Accessing protected members in a deep copy method is necessary
         node._key = self._key
         node.node_type = self.node_type
-        _memo[id(self)] = node
         return node
 
 

--- a/flypipe/node_function.py
+++ b/flypipe/node_function.py
@@ -90,13 +90,15 @@ class NodeFunction(Node):
 
         return [node.copy() for node in list(nodes)]
 
-    def copy(self, _memo: dict = None):
-        # See Node.copy: ``_memo`` maps id(node) -> copy so shared dependencies are
-        # copied once per copying pass instead of once per path through the DAG.
-        if _memo is None:
-            _memo = {}
-        if id(self) in _memo:
-            return _memo[id(self)]
+    def _predecessor_nodes(self):
+        # See Node._predecessor_nodes: a node function's predecessors
+        # (node_dependencies) are bare nodes, not InputNode wrappers.
+        return self.node_dependencies
+
+    def _copy_node(self, _memo: dict):
+        # See Node._copy_node: copy() (inherited from Node) has already copied
+        # every dependency into ``_memo``, so the copy calls below resolve from
+        # the memo without recursing.
         node_function = NodeFunction(
             self.function,
             node_dependencies=[
@@ -107,7 +109,6 @@ class NodeFunction(Node):
         )
 
         node_function._key = self._key
-        _memo[id(self)] = node_function
         return node_function
 
 

--- a/flypipe/node_function_test.py
+++ b/flypipe/node_function_test.py
@@ -247,6 +247,42 @@ class TestNodeFunction:
         assert func_copy.node_dependencies[0] is not t1
         assert func_copy.node_dependencies[0] is t1_input_copy
 
+    def test_copy_deep_chain_does_not_hit_recursion_limit(self):
+        """
+        NodeFunction shares Node.copy's explicit-stack traversal, so a chain of
+        node functions far deeper than recursive descent allows (it overflowed
+        Python's default recursion limit at a few hundred levels) must copy
+        successfully and preserve the whole chain.
+        """
+        depth = 2000
+
+        @node(type="pandas")
+        def seed():
+            return pd.DataFrame({"c1": [1]})
+
+        chain = [seed]
+        for i in range(1, depth):
+            prev = chain[-1]
+
+            def func():
+                return None
+
+            func.__name__ = f"f_{i}"
+            chain.append(node_function(node_dependencies=[prev])(func))
+
+        tail_copy = chain[-1].copy()
+
+        length = 0
+        current = tail_copy
+        while isinstance(current, NodeFunction):
+            length += 1
+            assert current.key == chain[depth - length].key
+            assert current is not chain[depth - length]
+            current = current.node_dependencies[0]
+        assert length == depth - 1  # every node-function link survived the copy
+        assert current.key == seed.key
+        assert current is not seed
+
     def test_node_function_output_is_none_but_return_node_has_output(self):
         col1 = Column("col1", String(), "test")
 

--- a/flypipe/node_test.py
+++ b/flypipe/node_test.py
@@ -1079,3 +1079,41 @@ class TestNode:
             tail_copy2.input_nodes[0].node.input_nodes[0].node
             is not left_copy.input_nodes[0].node
         )
+
+    def test_copy_deep_chain_does_not_hit_recursion_limit(self):
+        """
+        Node.copy walks ancestors with an explicit stack, so it must handle
+        serial chains far deeper than recursive descent allows (which cost ~3
+        stack frames per dependency level and so overflowed Python's default
+        recursion limit of 1000 at ~330 nodes), and the copy must preserve the
+        whole chain.
+        """
+        depth = 2000
+
+        @node(type="pandas")
+        def head():
+            return pd.DataFrame(data={"c1": [1]})
+
+        chain = [head]
+        for i in range(1, depth):
+
+            def transformation(df):
+                return df
+
+            transformation.__name__ = f"n_{i}"
+            chain.append(
+                node(type="pandas", dependencies=[chain[-1].alias("df")])(
+                    transformation
+                )
+            )
+
+        tail_copy = chain[-1].copy()
+
+        # Walk the copy from tail to head: every link survived, in order, and
+        # every node is a fresh object.
+        current = tail_copy
+        for original in reversed(chain):
+            assert current.key == original.key
+            assert current is not original
+            current = current.input_nodes[0].node if current.input_nodes else None
+        assert current is None


### PR DESCRIPTION
## Problem

`Node.copy()` walks the ancestor DAG by recursive descent: `Node.copy` → `InputNode.copy` → `Node.copy` of the wrapped node, and so on up the graph. Each dependency level costs ~3 Python stack frames, so with the default recursion limit of 1000 the copy blows up at **exactly 333 chained nodes** (verified empirically: 332 copies fine, 333 raises `RecursionError`). Since `NodeGraph._build_graph` copies the transformation at the start of every run, any sufficiently deep linear pipeline cannot run at all.

The `_memo` introduced in #223 doesn't help here: memoization prunes *re-visits*, but the **first descent** still has to recurse the full depth of the chain before anything lands in the memo.

Closes #226.

## Change

`Node.copy()` is now an **iterative, explicit-stack, dependency-first (post-order) traversal**. The recursion-depth ceiling is gone — stack frames stay O(1) regardless of graph depth; the traversal state lives in a heap-allocated list.

The driver is written once in `Node` and parameterized by two small polymorphic hooks, so `NodeFunction` drops its own recursive `copy()` override entirely and inherits the driver:

| hook | `Node` | `NodeFunction` |
|---|---|---|
| `_predecessor_nodes()` — "which nodes do I consume?" | unwraps `input_node.node` from the per-edge `InputNode` wrappers | returns `node_dependencies` (bare nodes) |
| `_copy_node(_memo)` — "copy just me" | the old `Node.copy` construction body, field-for-field | the old `NodeFunction.copy` construction body |

This is essentially the sketch from #226, with two simplifications: no separate collect + Kahn's-algorithm pass (the explicit-stack post-order *is* a topological order, computed in the same walk), and **no `InputNode` changes at all** — `InputNode.copy(_memo)` still calls `self.node.copy(_memo)`, but the driver guarantees every predecessor is already memoized by the time a node is constructed, so that call resolves from the memo fast-path at constant depth.

Semantics are unchanged: the memo is still keyed by `id()` (distinct objects sharing a key are copied separately, preserving last-wins assembly semantics), shared ancestors in diamonds still come out as a single shared copy, `InputNode` wrappers stay per-edge with their alias/`selected_columns`/preprocess/static state, and a `NodeFunction` threaded through a `Node` graph shares the same memo.

Two parity details surfaced by adversarial review of the rewrite:

- **`stack.extend(reversed(pending))`** — a plain `extend` onto a LIFO stack would copy sibling subtrees right-to-left, flipping construction-time side-effect order vs. the recursive code (observable via which node a `require_node_description` `ValueError` names first, and last-wins `Cache.set_parent` when siblings share a cache instance). `reversed` restores the exact left-to-right order.
- **Cycle guard** — the recursive code failed fast on a dependency cycle with `RecursionError`; a naive iterative loop would hang silently instead. The `expanding` set restores fail-fast with a clear `ValueError("Dependency cycle detected …")`. It cannot false-positive: in a DAG, a node that resurfaces on the stack always has all predecessors memoized, so resurfacing *with pending predecessors* is only possible if one of them leads back to it. (Cycles aren't constructible through the public API — dependencies must exist at decoration time — so this only protects against post-construction mutation of `input_nodes`.)

## How the new copy works

Take the graph **A→C, A→B, B→C** (arrows = data flow, so C consumes A and B; B consumes A) and call `C.copy()`. The loop looks at the top of the stack without popping and lands in one of three cases: *already copied → discard*, *has uncopied predecessors → push them and wait*, *all predecessors copied → build it*.

```text
stack [C]            C waits, pushes its predecessors      expanding={C}
stack [C, B, A]      A: no predecessors  -> A' built       _memo={A'}
stack [C, B]         B: A already copied -> B' built (wraps A')
stack [C]            C resurfaces, nothing pending -> C' built (wraps A', B')
stack []             return C'
```

Two moments carry the whole design: **B finds A already in the memo** (shared ancestor copied once, not once per consumer), and **C resurfaces with nothing pending** (the DAG property the cycle guard relies on).

<details>
<summary>Line-by-line trace (every executed line, with <code>current</code> / <code>pending</code> / <code>stack</code> / <code>expanding</code> / <code>_memo</code> after each)</summary>

`A`, `B`, `C` stand for `id(node)`; `A'` is the copy of A. State columns show values **after** the line executes; the stack grows to the right.

| # | code | result | `current` | `pending` | `stack` | `expanding` | `_memo` |
|---|------|--------|-----------|-----------|---------|-------------|---------|
| 1 | `_memo = {}` | fresh pass | – | – | – | – | `{}` |
| 2 | `id(C) in _memo?` | no | – | – | – | – | `{}` |
| 3 | `stack = [self]` | | – | – | `[C]` | – | `{}` |
| 4 | `expanding = set()` | | – | – | `[C]` | `{}` | `{}` |
| | **— iteration 1 —** | | | | | | |
| 5 | `current = stack[-1]` | peek, no pop | `C` | – | `[C]` | `{}` | `{}` |
| 6 | `id(C) in _memo?` | no | `C` | – | `[C]` | `{}` | `{}` |
| 7 | `pending = [...]` | both predecessors uncopied | `C` | `[A, B]` | `[C]` | `{}` | `{}` |
| 8 | `id(C) in expanding?` | no → no cycle | `C` | `[A, B]` | `[C]` | `{}` | `{}` |
| 9 | `expanding.add(C)` | C now waits | `C` | `[A, B]` | `[C]` | `{C}` | `{}` |
| 10 | `stack.extend(reversed(pending))` | pushed `[B, A]`, A on top | `C` | `[A, B]` | `[C, B, A]` | `{C}` | `{}` |
| | **— iteration 2 —** | | | | | | |
| 11 | `current = stack[-1]` | | `A` | – | `[C, B, A]` | `{C}` | `{}` |
| 12 | `pending = [...]` | A has no predecessors | `A` | `[]` | `[C, B, A]` | `{C}` | `{}` |
| 13 | `stack.pop()` | | `A` | `[]` | `[C, B]` | `{C}` | `{}` |
| 14 | `_memo[A] = A._copy_node(_memo)` | **A' built** | `A` | `[]` | `[C, B]` | `{C}` | `{A: A'}` |
| | **— iteration 3 —** | | | | | | |
| 15 | `current = stack[-1]` | | `B` | – | `[C, B]` | `{C}` | `{A: A'}` |
| 16 | `pending = [...]` | A already copied → empty | `B` | `[]` | `[C, B]` | `{C}` | `{A: A'}` |
| 17 | `stack.pop()` | | `B` | `[]` | `[C]` | `{C}` | `{A: A'}` |
| 18 | `_memo[B] = B._copy_node(_memo)` | **B' built, wrapping A' from the memo** | `B` | `[]` | `[C]` | `{C}` | `{A: A', B: B'}` |
| | **— iteration 4 —** | | | | | | |
| 19 | `current = stack[-1]` | C resurfaces | `C` | – | `[C]` | `{C}` | `{A: A', B: B'}` |
| 20 | `pending = [...]` | empty, as DAGs guarantee | `C` | `[]` | `[C]` | `{C}` | `{A: A', B: B'}` |
| 21 | `stack.pop()` | | `C` | `[]` | `[]` | `{C}` | `{A: A', B: B'}` |
| 22 | `expanding.discard(C)` | C stops waiting | `C` | `[]` | `[]` | `{}` | `{A: A', B: B'}` |
| 23 | `_memo[C] = C._copy_node(_memo)` | **C' built, wrapping A' and B'** | `C` | `[]` | `[]` | `{}` | `{A: A', B: B', C: C'}` |
| 24 | `return _memo[id(self)]` | returns `C'` | – | – | `[]` | `{}` | `{A: A', B: B', C: C'}` |

With declaration order `dependencies=[B, A]` instead, B surfaces before A is copied, so A is pushed twice (`stack=[C, A, B, A]`, `expanding={C, B}`) — the first occurrence builds `A'`, and the second surfaces later, hits `id(A) in _memo`, and is popped without rebuilding anything. Same final result, different route through the branches.

</details>

## Verification

- New regression tests copy **2000-deep chains** (`node_test.py` for plain nodes, `node_function_test.py` for node-function chains, which recursed through the same pattern at 2 frames/level). Both fail with `RecursionError` against `main` and pass here in <0.1s.
- Existing copy-semantics tests pass unchanged: diamond shared-ancestor identity, per-edge wrapper state, node-function memo sharing.
- Full local suite: 287 passed, 28 skipped. The 2 `utils_test.py` failures in a full-directory sweep reproduce **identically on `main`** (test-ordering pollution; both pass in isolation) — pre-existing, unrelated.
- Performance measured linear, no hidden quadratic: dense sliding-window graphs (each node depending on the previous 50) copy in 81.6 / 162.9 / 329.3 ms at n=1000/2000/4000 (2.0× per size doubling); an 8000-node chain copies in 33 ms.
- End-to-end: a 1000-node serial chain runs through `Runner` with flat RSS across repeated runs.
- The rewrite was adversarially reviewed (independent correctness / semantic-parity / edge-case / tests-and-perf passes, each finding empirically verified against `main`); the `reversed()` and cycle-guard items above were its findings, both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
